### PR TITLE
Null check for scene hit sound

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -82,9 +82,9 @@ The following configuration is universal to all target types.
 * `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified. A value of `-1` creates a target that respawns infinitely (trial ends when ammo or task time runs out).
 * `visualSize` is a vector indicating the minimum ([0]) and maximum ([1]) visual size for the target (in deg)
 * `destSpace` the space for which the target is rendered (useful for non-destiantion based targets, "player" or "world")
-* `hitSound` is a filename for the sound to play when the target is hit but not destroyed.
+* `hitSound` is a filename for the sound to play when the target is hit but not destroyed (for no sound use an empty string).
 * `hitSoundVol` provides the volume (as a float) for the hit sound to be played at (default is `1.0`).
-* `destroyedSound` is a filename for the sound to play when the target is both hit and destroyed.
+* `destroyedSound` is a filename for the sound to play when the target is both hit and destroyed (for no sound use an empty string).
 * `destroyedSoundVol` provides the volume (as a float) for the destroyed sound to be played at (default is `1.0`).
 * `destroyDecal` the decal to show when destroyed
 * `destroyDecalScale` a scale to apply the the destroy decal (may be decal dependent)

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -151,10 +151,10 @@ allSessionsCompleteFeedback: "All Sessions Complete!",
 ```
 
 ## Audio Settings
-| Parameter Name        |Units  | Description                                                           |
-|-----------------------|-------|-----------------------------------------------------------------------|
-|`sceneHitSound`        |file   | The sound to play when the scene (not the target) is hit by a weapon  |
-|`sceneHitSoundVol`     |ratio  | The volume of the scene hit sound to play                             |
+| Parameter Name        |Units  | Description                                                                                               |
+|-----------------------|-------|-----------------------------------------------------------------------------------------------------------|
+|`sceneHitSound`        |file   | The sound to play when the scene (not the target) is hit by a weapon (for no sound use an empty string)   |
+|`sceneHitSoundVol`     |ratio  | The volume of the scene hit sound to play                                                                 |
 
 ```
 "sceneHitSound": "sound/fpsci_miss_100ms.wav",

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -42,13 +42,13 @@ This file provides information about the weapon to be used in the experiment. De
 ## Sound and View Model
 Controls specific to the sound/view model for the weapon are provided below:
 
-| Parameter Name        |Units      | Description                                                                                           |
-|-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
-|`fireSound`            |file       | The filename/location of the audio clip to use for the weapon firing                                  |
-|`fireSoundVol`         |ratio      | The volume to play the `fireSound` clip with                                                          |
-|`renderModel`          |`bool`     | Whether or not a weapon model is rendered in the first-person view                                    |
-|`modelSpec`            |`ArticulatedModel::Specification` | Any-based specification for the weapon being used                              |
-|`kickAngleDegrees`     |`float`    | The angle (in degrees) the weapon model should kick after fire                                        |
+| Parameter Name        |Units      | Description                                                                                               |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------|
+|`fireSound`            |file       | The filename/location of the audio clip to use for the weapon firing (for no sound use an empty string)   |
+|`fireSoundVol`         |ratio      | The volume to play the `fireSound` clip with                                                              |
+|`renderModel`          |`bool`     | Whether or not a weapon model is rendered in the first-person view                                        |
+|`modelSpec`            |`ArticulatedModel::Specification` | Any-based specification for the weapon being used                                  |
+|`kickAngleDegrees`     |`float`    | The angle (in degrees) the weapon model should kick after fire                                            |
 |`kickDuration`         |`float`    | The time over which the weapon kick animates following a shot (in seconds). Recommended to be less than or equal to the `firePeriod`. |
 
 ```

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -777,7 +777,7 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 		if (isNull(target)) // Miss case
 		{
 			// Play scene hit sound
-			if (!weapon->config()->isContinuous()) {
+			if (!weapon->config()->isContinuous() && notNull(m_sceneHitSound)) {
 				m_sceneHitSound->play(sessConfig->audio.sceneHitSoundVol);
 			}
 		}

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -320,11 +320,11 @@ void Weapon::playSound(bool shotFired, bool shootButtonUp) {
 				m_fireAudio->setPaused(false);
 			}
 		}
-		else if (shotFired) {
+		else if (shotFired && notNull(m_fireSound)) {
 			m_fireAudio = m_fireSound->play(m_config->fireSoundVol);
 		}
 	}
-	else if (shotFired) {
+	else if (shotFired && notNull(m_fireSound)) {
 		m_fireSound->play(m_config->fireSoundVol);
 	}
 }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -159,7 +159,8 @@ public:
 	void loadSounds() {
 		// Check for play mode specific parameters
 		if (notNull(m_fireAudio)) { m_fireAudio->stop(); }
-		m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->isContinuous());
+		if(!m_config->fireSound.empty()) m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->isContinuous());
+		else { m_fireSound = nullptr; }
 	}
 	// Plays the sound based on the weapon fire mode
 	void playSound(bool shotFired, bool shootButtonUp);


### PR DESCRIPTION
Fixes an issue where an empty string value for `sceneHitSound` in the experiment/session config resulted in a null pointer exception at runtime.