### PR TITLE
Experiment config validation

### DIFF
--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -1,5 +1,5 @@
 # Introduction
-The startup config is the highest level configuration file provided to `FirstPersonScience`. This file specifies the experiment configuration path, as well as the user configuration path and play mode.
+The startup config is the highest level configuration file provided to `FirstPersonScience`. This file specifies the experiment configuration path, as well as the user configuration path and play mode. Unlike other config files that can be reloaded with the `reloadConfigs` keybind (F5 by default) when in developer mode (`developerMode`=`true`), the startup config is only loaded at startup. For this reason, if you make changes to the startup config you must restart to see those changes.
 
 ## File Location
 The `startupconfig.Any` file is located in the [`data-files` directory](../data-files/) in the root of the project. If no `startupconfig.Any` is present at launch the application will create one.

--- a/source/ExperimentConfig.cpp
+++ b/source/ExperimentConfig.cpp
@@ -88,7 +88,7 @@ void ExperimentConfig::init() {
 	}
 }
 
-ExperimentConfig ExperimentConfig::load(const String& filename, bool validate) {
+ExperimentConfig ExperimentConfig::load(const String& filename) {
 	ExperimentConfig ex;
 	if (!FileSystem::exists(System::findDataFile(filename, false))) {
 		// if file not found, save the default
@@ -98,7 +98,6 @@ ExperimentConfig ExperimentConfig::load(const String& filename, bool validate) {
 	else {
 		ex = Any::fromFile(System::findDataFile(filename));
 	}
-	if (validate) { ex.validate(); }
 	return ex;
 }
 
@@ -168,7 +167,8 @@ Array<shared_ptr<TargetConfig>> ExperimentConfig::getSessionTargets(const String
 	return targets;
 }
 
-bool ExperimentConfig::validate(bool exception) const {
+bool ExperimentConfig::validate(bool throwException) const {
+	bool valid = true;
 	// Build list of valid target ids
 	Array<String> validTargetIds;
 	for (TargetConfig target : targets) { validTargetIds.append(target.id); }
@@ -183,12 +183,17 @@ bool ExperimentConfig::validate(bool exception) const {
 		// Check each ID against the experiment targets array
 		for (String targetId : sessionTargetIds) {
 			if (!validTargetIds.contains(targetId)) {
-				if (exception) { throw format("Could not find target ID \"%s\" used in session \"%s\"!", targetId, session.id); }
-				return false;
+				if (throwException) {
+					throw format("Could not find target ID \"%s\" used in session \"%s\"!", targetId, session.id);
+				}
+				else {
+					logPrintf("  Could not find target ID \"%s\" used in session \"%s\"!\n", targetId, session.id);
+				}
+				valid = false;
 			}
 		}
 	}
-	return true;
+	return valid;
 }
 
 Any ExperimentConfig::toAny(const bool forceAll) const {

--- a/source/ExperimentConfig.cpp
+++ b/source/ExperimentConfig.cpp
@@ -88,15 +88,18 @@ void ExperimentConfig::init() {
 	}
 }
 
-ExperimentConfig ExperimentConfig::load(const String& filename) {
-	// if file not found, build a default
+ExperimentConfig ExperimentConfig::load(const String& filename, bool validate) {
+	ExperimentConfig ex;
 	if (!FileSystem::exists(System::findDataFile(filename, false))) {
-		ExperimentConfig ex = ExperimentConfig();
+		// if file not found, save the default
 		ex.toAny().save(filename);
 		SessionConfig::defaultConfig = (FpsConfig)ex;
-		return ex;
 	}
-	return Any::fromFile(System::findDataFile(filename));
+	else {
+		ex = Any::fromFile(System::findDataFile(filename));
+	}
+	if (validate) { ex.validate(); }
+	return ex;
 }
 
 void ExperimentConfig::getSessionIds(Array<String>& ids) const {
@@ -150,12 +153,12 @@ Array<Array<shared_ptr<TargetConfig>>> ExperimentConfig::getTargetsByTrial(int s
 	return trials;
 }
 
-Array<shared_ptr<TargetConfig>> ExperimentConfig::getSessionTargets(const String& id) {
+Array<shared_ptr<TargetConfig>> ExperimentConfig::getSessionTargets(const String& id) const {
 	const int idx = getSessionIndex(id);		// Get session index
 	Array<shared_ptr<TargetConfig>> targets;
 	Array<String> loggedIds;
 	for (auto trial : sessions[idx].trials) {
-		for (String id : trial.ids) {
+		for (String& id : trial.ids) {
 			if (!loggedIds.contains(id)) {
 				loggedIds.append(id);
 				targets.append(getTargetConfigById(id));
@@ -163,6 +166,29 @@ Array<shared_ptr<TargetConfig>> ExperimentConfig::getSessionTargets(const String
 		}
 	}
 	return targets;
+}
+
+bool ExperimentConfig::validate(bool exception) const {
+	// Build list of valid target ids
+	Array<String> validTargetIds;
+	for (TargetConfig target : targets) { validTargetIds.append(target.id); }
+
+	// Validate session targets against provided experiment target list
+	for (SessionConfig session : sessions) {
+		Array<String> sessionTargetIds;
+		// Build a list of target ids used in this session
+		for (TrialCount trial : session.trials) {
+			for (String id : trial.ids) { if (!sessionTargetIds.contains(id)) sessionTargetIds.append(id); }
+		}
+		// Check each ID against the experiment targets array
+		for (String targetId : sessionTargetIds) {
+			if (!validTargetIds.contains(targetId)) {
+				if (exception) { throw format("Could not find target ID \"%s\" used in session \"%s\"!", targetId, session.id); }
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 Any ExperimentConfig::toAny(const bool forceAll) const {

--- a/source/ExperimentConfig.h
+++ b/source/ExperimentConfig.h
@@ -16,7 +16,7 @@ public:
 	ExperimentConfig(const Any& any);
 
 	void init();
-	static ExperimentConfig load(const String& filename, bool validate = true);	// Get the experiment config from file
+	static ExperimentConfig load(const String& filename);	// Get the experiment config from file
 	Any toAny(const bool forceAll = false) const;
 
 	void getSessionIds(Array<String>& ids) const;								// Get an array of session IDs
@@ -28,7 +28,7 @@ public:
 	Array<Array<shared_ptr<TargetConfig>>> getTargetsByTrial(int sessionIndex) const;			// Get target configs by trial (not recommended for repeated calls)
 	Array<shared_ptr<TargetConfig>> getSessionTargets(const String& id) const;					// Get all targets affiliated with a session (not recommended for repeated calls)
 
-	bool validate(bool exception=true) const;									// Validate the session/target configuration
+	bool validate(bool throwException) const;									// Validate the session/target configuration
 
 	void printToLog() const;													// Print the config to the log
 };

--- a/source/ExperimentConfig.h
+++ b/source/ExperimentConfig.h
@@ -16,7 +16,7 @@ public:
 	ExperimentConfig(const Any& any);
 
 	void init();
-	static ExperimentConfig load(const String& filename);						// Get the experiment config from file
+	static ExperimentConfig load(const String& filename, bool validate = true);	// Get the experiment config from file
 	Any toAny(const bool forceAll = false) const;
 
 	void getSessionIds(Array<String>& ids) const;								// Get an array of session IDs
@@ -26,7 +26,9 @@ public:
 
 	Array<Array<shared_ptr<TargetConfig>>> getTargetsByTrial(const String& id) const;			// Get target configs by trial (not recommended for repeated calls)
 	Array<Array<shared_ptr<TargetConfig>>> getTargetsByTrial(int sessionIndex) const;			// Get target configs by trial (not recommended for repeated calls)
-	Array<shared_ptr<TargetConfig>> getSessionTargets(const String& id);		// Get all targets affiliated with a session (not recommended for repeated calls)
+	Array<shared_ptr<TargetConfig>> getSessionTargets(const String& id) const;					// Get all targets affiliated with a session (not recommended for repeated calls)
+
+	bool validate(bool exception=true) const;									// Validate the session/target configuration
 
 	void printToLog() const;													// Print the config to the log
 };

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -28,17 +28,25 @@ void FPSciApp::onInit() {
 
 void FPSciApp::initExperiment(){
 	// Validate experiment configs
-	for (auto configs = startupConfig.experimentList.begin(); configs != startupConfig.experimentList.end(); ++configs) {
-		experimentConfig = ExperimentConfig::load(configs->experimentConfigFilename);
-		logPrintf("Validating experiment '%s'\n", configs->name);
-		bool valid = experimentConfig.validate(false);
-		if (!valid) {
-			logPrintf("Experiment '%s' excluded from the list!\n", configs->name);
-			startupConfig.experimentList.remove(configs);
+	if (startupConfig.experimentList.length() != 1) {
+		// Create list of configs to remove logging to log.txt
+		Array<ConfigFiles*> toRemove;
+		for (auto configs = startupConfig.experimentList.begin(); configs != startupConfig.experimentList.end(); ++configs) {
+			experimentConfig = ExperimentConfig::load(configs->experimentConfigFilename);
+			logPrintf("Validating experiment '%s'\n", configs->name);
+			bool valid = experimentConfig.validate(false);
+			if (!valid) {
+				logPrintf("Experiment '%s' excluded from the list!\n", configs->name);
+				toRemove.append(configs);
+			}
 		}
-	}
-	if (startupConfig.experimentList.length() <= 0) {
-		throw("No valid experiments found in experiment list. Check log.txt for details.");
+		// Actually remove the configs from the list
+		for (auto configs = toRemove.begin(); configs != toRemove.end(); ++configs) {
+			startupConfig.experimentList.remove(*configs);
+		}
+		if (startupConfig.experimentList.length() <= 0) {
+			throw("No valid experiments found in experiment list. Check log.txt for details.");
+		}
 	}
 
 	// Load config from files

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -23,32 +23,11 @@ void FPSciApp::onInit() {
 	Random::common().reset(uint32(time(0)));
 
 	GApp::onInit();			// Initialize the G3D application (one time)
+	startupConfig.validateExperiments();
 	initExperiment();		// Initialize the experiment
 }
 
 void FPSciApp::initExperiment(){
-	// Validate experiment configs
-	if (startupConfig.experimentList.length() != 1) {
-		// Create list of configs to remove logging to log.txt
-		Array<ConfigFiles*> toRemove;
-		for (auto configs = startupConfig.experimentList.begin(); configs != startupConfig.experimentList.end(); ++configs) {
-			experimentConfig = ExperimentConfig::load(configs->experimentConfigFilename);
-			logPrintf("Validating experiment '%s'\n", configs->name);
-			bool valid = experimentConfig.validate(false);
-			if (!valid) {
-				logPrintf("Experiment '%s' excluded from the list!\n", configs->name);
-				toRemove.append(configs);
-			}
-		}
-		// Actually remove the configs from the list
-		for (auto configs = toRemove.begin(); configs != toRemove.end(); ++configs) {
-			startupConfig.experimentList.remove(*configs);
-		}
-		if (startupConfig.experimentList.length() <= 0) {
-			throw("No valid experiments found in experiment list. Check log.txt for details.");
-		}
-	}
-
 	// Load config from files
 	loadConfigs(startupConfig.experimentList[experimentIdx]);
 	m_lastSavedUser = *currentUser();			// Copy over the startup user for saves

--- a/source/StartupConfig.cpp
+++ b/source/StartupConfig.cpp
@@ -1,4 +1,5 @@
 #include "StartupConfig.h"
+#include "ExperimentConfig.h"
 
 ConfigFiles::ConfigFiles(const Any& any) {
 	AnyTableReader reader(any);
@@ -128,4 +129,18 @@ Any StartupConfig::toAny(const bool forceAll) const {
 	a["experimentList"] = experimentList;
 
 	return a;
+}
+
+bool StartupConfig::validateExperiments() const {
+	// Validate experiment configs
+	bool valid = true;
+	for (auto& configs : experimentList) {
+		ExperimentConfig experimentConfig = ExperimentConfig::load(configs.experimentConfigFilename);
+		logPrintf("Validating experiment '%s'\n", configs.name);
+		if (!experimentConfig.validate(false)) {
+			logPrintf("Experiment '%s' excluded from the list!\n", configs.name);
+			valid = false;
+		}
+	}
+	return valid;
 }

--- a/source/StartupConfig.cpp
+++ b/source/StartupConfig.cpp
@@ -138,7 +138,7 @@ bool StartupConfig::validateExperiments() const {
 		ExperimentConfig experimentConfig = ExperimentConfig::load(configs.experimentConfigFilename);
 		logPrintf("Validating experiment '%s'\n", configs.name);
 		if (!experimentConfig.validate(false)) {
-			logPrintf("Experiment '%s' excluded from the list!\n", configs.name);
+			logPrintf("  Error: experiment '%s' is not valid! (See '%s')\n", configs.name, configs.experimentConfigFilename);
 			valid = false;
 		}
 	}

--- a/source/StartupConfig.h
+++ b/source/StartupConfig.h
@@ -43,5 +43,6 @@ public:
 	StartupConfig(const Any& any);								///< Any constructor
 
 	static StartupConfig load(const String& filename);			///< Load the startup config from file (create if needed)
-	Any toAny(const bool forceAll = true) const;				///< Conver to any
+	Any toAny(const bool forceAll = true) const;				///< Convert to any
+	bool validateExperiments() const;							///< Validate the experiments in the experiment list
 };


### PR DESCRIPTION
This branch adds support for an `ExperimentConfig::validate()` routine that is called (optionally) on `ExperimentConfig::load()`. Specifically this validate routine checks that the set of target ids used in session `TrialCount` objects match the global list of targets specified in the experiment config `targets` array.

Merging this PR closes #289.