### PR TITLE
Default user to userconfig.Any

### DIFF
--- a/source/UserConfig.cpp
+++ b/source/UserConfig.cpp
@@ -110,8 +110,9 @@ UserTable UserTable::load(const String& filename) {
 
 Any UserTable::toAny(const bool forceAll) const {
 	Any a(Any::TABLE);
-	a["settingsVersion"] = 1;						///< Create a version 1 file
-	a["users"] = users;								///< Include updated subject table
+	a["settingsVersion"] = 1;						// Create a version 1 file
+	if (forceAll || !(defaultUser == UserConfig())) a["defaultUser"] = defaultUser;					// Add default user
+	a["users"] = users;								// Include updated subject table
 	return a;
 }
 

--- a/source/UserConfig.h
+++ b/source/UserConfig.h
@@ -22,7 +22,7 @@ public:
 	UserConfig() {};
 	UserConfig(const Any& any);
 
-	Any toAny(const bool forceAll = true) const;
+	Any toAny(const bool forceAll = false) const;
 	bool operator==(const UserConfig& other) const;
 
 };
@@ -37,7 +37,7 @@ public:
 	UserTable() {};
 	UserTable(const Any& any);
 
-	Any toAny(const bool forceAll = true) const;
+	Any toAny(const bool forceAll = false) const;
 
 	shared_ptr<UserConfig> getUserById(const String& id) const;			// Get a user config based on a user ID
 	static UserTable load(const String& filename);						// Get the user config from file (or create it if it doesn't exist)


### PR DESCRIPTION
This branch adds support for serializing the `defaultUser` of the user config back out when a user is updated/created.

Merging this PR closes #291.