### PR TITLE
Clearing miss decals on new sessions/trials

### DIFF
--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -90,6 +90,7 @@ Controls specific to the miss decals drawn in the scene are included below:
 |`missDecal`            |`String`   | The filename of an image to use for miss decals. Can be set to `""` for no decals.
 |`missDecalCount`       |`int`      | The maximum number of miss decals to draw from this weapon (oldest are removed first). Can be set to `0` for no decals.|
 |`missDecalScale`       |`float`    | A scale to apply to the miss decals drawn by this weapon, `1.0` means do not scale                     |
+|`clearTrialMissDecals` |`bool`     | Whether or not to clear miss decals at the end of each trial (automatically cleared at the end of each session). |
 |`hitDecal`             |`String`   | The filename of an image to use for hit decals. Can be set to `""` for no decals.                      |
 |`hitDecalScale`        |`float`    | A scale to apply to the hit decals drawn by this weapon. `1.0` means do not scale.                     |
 |`hitDecalDuration`     |s          | The duration to draw a hit decal for (in seconds).                                                     |
@@ -100,6 +101,7 @@ Controls specific to the miss decals drawn in the scene are included below:
     "missDecal" : "bullet-decal-256x256.png";       // Included in FPSci
     "missDecalCount" : 2;                           // Number of miss decals to draw (at once)
     "missDecalScale" : 1.0;                         // Don't scale the miss decal (1.0x scale)
+    "clearTrialMissDecals": true,                   // Clear miss decals on the end of each trial
     "hitDecalScale" : 1.0;                          // Don't scale the hit decal  (1.0x scale)
     "hitDecalDurationS" : 0.1;                      // Draw the decal for 0.1s
     "hitDecalColorMult" = 2.0;                      // Slightly emissive hit decal

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -82,6 +82,14 @@ Controls specific to the projectiles fired by the weapon are included below:
 ```
 
 ## Decal Control
+There are 2 types of weapon decals in FPSci, hit decals and miss decals. Hit decals are drawn on a target at the hit location, while miss decals are drawn to the scene at the point of a miss.
+
+Currently FPSci supports only 1 hit decal being presented at a time, but a configurable amount (`missDecalCount`) of miss decals. Hit decals are removed after a timeout (`hitDecalDuration`) or when a new hit decal is created (whichever happens first). Miss decals are removed based on one of three criteria:
+
+- A new miss decal is created, bringing the total count of miss decals above `missDecalCount`, in this case oldest decal is removed
+- The decal has existed for `missDecalTimeoutS`
+- The current trial ends and `clearTrialMissDecals` is `true`, or the current session ends
+
 Controls specific to the miss decals drawn in the scene are included below:
 
 | Parameter Name        |Units      | Description                                                                                           |
@@ -90,6 +98,7 @@ Controls specific to the miss decals drawn in the scene are included below:
 |`missDecal`            |`String`   | The filename of an image to use for miss decals. Can be set to `""` for no decals.
 |`missDecalCount`       |`int`      | The maximum number of miss decals to draw from this weapon (oldest are removed first). Can be set to `0` for no decals.|
 |`missDecalScale`       |`float`    | A scale to apply to the miss decals drawn by this weapon, `1.0` means do not scale                     |
+|`missDecalTimeoutS`    |s          | The duration to display a miss decal for (in seconds). Use `-1` to set to never timeout.               |
 |`clearTrialMissDecals` |`bool`     | Whether or not to clear miss decals at the end of each trial (automatically cleared at the end of each session). |
 |`hitDecal`             |`String`   | The filename of an image to use for hit decals. Can be set to `""` for no decals.                      |
 |`hitDecalScale`        |`float`    | A scale to apply to the hit decals drawn by this weapon. `1.0` means do not scale.                     |
@@ -101,6 +110,7 @@ Controls specific to the miss decals drawn in the scene are included below:
     "missDecal" : "bullet-decal-256x256.png";       // Included in FPSci
     "missDecalCount" : 2;                           // Number of miss decals to draw (at once)
     "missDecalScale" : 1.0;                         // Don't scale the miss decal (1.0x scale)
+    "missDecalTimeoutS" : -1;                       // Don't clear hit decals until end of trial/session
     "clearTrialMissDecals": true,                   // Clear miss decals on the end of each trial
     "hitDecalScale" : 1.0;                          // Don't scale the hit decal  (1.0x scale)
     "hitDecalDurationS" : 0.1;                      // Draw the decal for 0.1s

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -84,7 +84,7 @@ Controls specific to the projectiles fired by the weapon are included below:
 ## Decal Control
 There are 2 types of weapon decals in FPSci, hit decals and miss decals. Hit decals are drawn on a target at the hit location, while miss decals are drawn to the scene at the point of a miss.
 
-Currently FPSci supports only 1 hit decal being presented at a time, but a configurable amount (`missDecalCount`) of miss decals. Hit decals are removed after a timeout (`hitDecalDuration`) or when a new hit decal is created (whichever happens first). Miss decals are removed based on one of three criteria:
+Currently FPSci supports only 1 hit decal being presented at a time, but a configurable amount (`missDecalCount`) of miss decals. Hit decals are removed after a timeout (`hitDecalTimeoutS`) or when a new hit decal is created (whichever happens first). Miss decals are removed based on one of three criteria:
 
 - A new miss decal is created, bringing the total count of miss decals above `missDecalCount`, in this case oldest decal is removed
 - The decal has existed for `missDecalTimeoutS`
@@ -102,7 +102,7 @@ Controls specific to the miss decals drawn in the scene are included below:
 |`clearTrialMissDecals` |`bool`     | Whether or not to clear miss decals at the end of each trial (automatically cleared at the end of each session). |
 |`hitDecal`             |`String`   | The filename of an image to use for hit decals. Can be set to `""` for no decals.                      |
 |`hitDecalScale`        |`float`    | A scale to apply to the hit decals drawn by this weapon. `1.0` means do not scale.                     |
-|`hitDecalDuration`     |s          | The duration to draw a hit decal for (in seconds).                                                     |
+|`hitDecalTimeoutS`     |s          | The duration to draw a hit decal for (in seconds).                                                     |
 |`hitDecalColorMult`    |`float`    | The value used to multiply colors for the hit decal (higher means brighter). Set >1 for "emissive".    |
 
 ```
@@ -113,7 +113,7 @@ Controls specific to the miss decals drawn in the scene are included below:
     "missDecalTimeoutS" : -1;                       // Don't clear hit decals until end of trial/session
     "clearTrialMissDecals": true,                   // Clear miss decals on the end of each trial
     "hitDecalScale" : 1.0;                          // Don't scale the hit decal  (1.0x scale)
-    "hitDecalDurationS" : 0.1;                      // Draw the decal for 0.1s
+    "hitDecalTimeoutS" : 0.1;                      // Draw the decal for 0.1s
     "hitDecalColorMult" = 2.0;                      // Slightly emissive hit decal
 ```
 
@@ -175,7 +175,7 @@ The config below provides an example for each of the fields above (along with th
 "missDecalScale": 1.0,      // Don't scale the decal
 "hitDecal" : "",            // No default hit decal
 "hitDecalScale": 1.0,       // Scale to apply to hit decal
-"hitDecalDuration": 0.1,    // Show the hit decal for 0.1s
+"hitDecalTimeoutS": 0.1,    // Show the hit decal for 0.1s
 "hitDecalColorMult": 2.0,   // Multiply the hit decal color values by 2 (pseudo-emissive)
 
 "renderMuzzleFlash": false, // Draw a muzzle flash

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -373,7 +373,9 @@ void Session::updatePresentationState()
 
 			// Reset weapon cooldown
 			m_weapon->resetCooldown();
-
+			if (m_weapon->config()->clearTrialMissDecals) {				// Clear weapon's decals if specified
+				m_weapon->clearDecals(false);
+			}
 		}
 	}
 	else if (currentState == PresentationState::trialFeedback)

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -309,7 +309,8 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 
 void Weapon::clearDecals() {
 	while (m_currentMissDecals.size() > 0) {
-		m_currentMissDecals.pop();
+		shared_ptr<VisibleEntity> decal = m_currentMissDecals.pop();
+		m_scene->remove(decal);
 	}
 	if (notNull(m_hitDecal)) {
 		m_scene->remove(m_hitDecal);

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -40,6 +40,7 @@ WeaponConfig::WeaponConfig(const Any& any) {
 		reader.getIfPresent("hitDecal", hitDecal);
 		reader.getIfPresent("missDecalCount", missDecalCount);
 		reader.getIfPresent("missDecalScale", missDecalScale);
+		reader.getIfPresent("clearTrialMissDecals", clearTrialMissDecals);
 		reader.getIfPresent("hitDecalScale", hitDecalScale);
 		reader.getIfPresent("hitDecalDuration", hitDecalDurationS);
 		reader.getIfPresent("hitDecalColorMult", hitDecalColorMult);
@@ -92,6 +93,7 @@ Any WeaponConfig::toAny(const bool forceAll) const {
 	if (forceAll || def.hitDecal != hitDecal)							a["hitDecal"] = hitDecal;
 	if (forceAll || def.missDecalCount != missDecalCount)				a["missDecalCount"] = missDecalCount;
 	if (forceAll || def.missDecalScale != missDecalScale)				a["missDecalScale"] = missDecalScale;
+	if (forceAll || def.clearTrialMissDecals != clearTrialMissDecals)	a["clearTrialMissDecals"] = clearTrialMissDecals;
 	if (forceAll || def.hitDecalScale != hitDecalScale)					a["hitDecalScale"] = hitDecalScale;
 	if (forceAll || def.hitDecalDurationS != hitDecalDurationS)			a["hitDecalDuration"] = hitDecalDurationS;
 	if (forceAll || def.hitDecalColorMult != hitDecalColorMult)			a["hitDecalColorMult"] = hitDecalColorMult;
@@ -307,11 +309,11 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 	}
 }
 
-void Weapon::clearDecals() {
+void Weapon::clearDecals(bool clearHitDecal) {
 	while (m_currentMissDecals.size() > 0) {
 		m_scene->remove(m_currentMissDecals.pop());
 	}
-	if (notNull(m_hitDecal)) {
+	if (clearHitDecal && notNull(m_hitDecal)) {
 		m_scene->remove(m_hitDecal);
 	}
 }

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -309,8 +309,7 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 
 void Weapon::clearDecals() {
 	while (m_currentMissDecals.size() > 0) {
-		shared_ptr<VisibleEntity> decal = m_currentMissDecals.pop();
-		m_scene->remove(decal);
+		m_scene->remove(m_currentMissDecals.pop());
 	}
 	if (notNull(m_hitDecal)) {
 		m_scene->remove(m_hitDecal);

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -43,7 +43,7 @@ WeaponConfig::WeaponConfig(const Any& any) {
 		reader.getIfPresent("missDecalTimeoutS", missDecalTimeoutS);
 		reader.getIfPresent("clearTrialMissDecals", clearTrialMissDecals);
 		reader.getIfPresent("hitDecalScale", hitDecalScale);
-		reader.getIfPresent("hitDecalDuration", hitDecalDurationS);
+		reader.getIfPresent("hitDecalTimeoutS", hitDecalTimeoutS);
 		reader.getIfPresent("hitDecalColorMult", hitDecalColorMult);
 
 		reader.getIfPresent("fireSpreadDegrees", fireSpreadDegrees);
@@ -97,7 +97,7 @@ Any WeaponConfig::toAny(const bool forceAll) const {
 	if (forceAll || def.missDecalTimeoutS != missDecalTimeoutS)			a["missDecalTimeoutS"] = missDecalTimeoutS;
 	if (forceAll || def.clearTrialMissDecals != clearTrialMissDecals)	a["clearTrialMissDecals"] = clearTrialMissDecals;
 	if (forceAll || def.hitDecalScale != hitDecalScale)					a["hitDecalScale"] = hitDecalScale;
-	if (forceAll || def.hitDecalDurationS != hitDecalDurationS)			a["hitDecalDuration"] = hitDecalDurationS;
+	if (forceAll || def.hitDecalTimeoutS != hitDecalTimeoutS)			a["hitDecalTimeoutS"] = hitDecalTimeoutS;
 	if (forceAll || def.hitDecalColorMult != hitDecalColorMult)			a["hitDecalColorMult"] = hitDecalColorMult;
 
 	if (forceAll || def.fireSpreadDegrees != fireSpreadDegrees)			a["fireSpreadDegrees"] = fireSpreadDegrees;
@@ -323,7 +323,7 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 	}
 	else {
 		m_hitDecal = newDecal;
-		m_hitDecalTimeRemainingS = m_config->hitDecalDurationS;
+		m_hitDecalTimeRemainingS = m_config->hitDecalTimeoutS;
 	}
 }
 

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -40,6 +40,7 @@ WeaponConfig::WeaponConfig(const Any& any) {
 		reader.getIfPresent("hitDecal", hitDecal);
 		reader.getIfPresent("missDecalCount", missDecalCount);
 		reader.getIfPresent("missDecalScale", missDecalScale);
+		reader.getIfPresent("missDecalTimeoutS", missDecalTimeoutS);
 		reader.getIfPresent("clearTrialMissDecals", clearTrialMissDecals);
 		reader.getIfPresent("hitDecalScale", hitDecalScale);
 		reader.getIfPresent("hitDecalDuration", hitDecalDurationS);
@@ -93,6 +94,7 @@ Any WeaponConfig::toAny(const bool forceAll) const {
 	if (forceAll || def.hitDecal != hitDecal)							a["hitDecal"] = hitDecal;
 	if (forceAll || def.missDecalCount != missDecalCount)				a["missDecalCount"] = missDecalCount;
 	if (forceAll || def.missDecalScale != missDecalScale)				a["missDecalScale"] = missDecalScale;
+	if (forceAll || def.missDecalTimeoutS != missDecalTimeoutS)			a["missDecalTimeoutS"] = missDecalTimeoutS;
 	if (forceAll || def.clearTrialMissDecals != clearTrialMissDecals)	a["clearTrialMissDecals"] = clearTrialMissDecals;
 	if (forceAll || def.hitDecalScale != hitDecalScale)					a["hitDecalScale"] = hitDecalScale;
 	if (forceAll || def.hitDecalDurationS != hitDecalDurationS)			a["hitDecalDuration"] = hitDecalDurationS;
@@ -273,6 +275,18 @@ void Weapon::simulateProjectiles(SimTime sdt, const Array<shared_ptr<TargetEntit
 	else {
 		m_hitDecalTimeRemainingS -= sdt;
 	}
+
+	// Handle miss decal removal (timeout)
+	for (int i = 0; i < m_missDecalTimesRemaining.length(); i++) {
+		if (m_missDecalTimesRemaining[i] < 0) continue;					// Skip decals with negative initial timeouts (don't timeout)
+		m_missDecalTimesRemaining[i] -= sdt;
+		if (m_missDecalTimesRemaining[i] <= 0) {
+			m_scene->remove(m_currentMissDecals[i]);
+			m_missDecalTimesRemaining.remove(i);
+			m_currentMissDecals.remove(i);
+			i--;
+		}
+	}
 }
 
 void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
@@ -290,6 +304,7 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 	if (!hit) {
 		while (m_currentMissDecals.size() >= m_config->missDecalCount) {
 			m_scene->remove(m_currentMissDecals.pop());
+			m_missDecalTimesRemaining.pop();
 		}
 	}
 	// Handle hit decal here (only show 1 at a time)
@@ -302,7 +317,10 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 	const shared_ptr<VisibleEntity>& newDecal = VisibleEntity::create(format("decal%03d", ++m_lastDecalID), &(*m_scene), decalModel, decalFrame);
 	newDecal->setCastsShadows(false);
 	m_scene->insert(newDecal);
-	if (!hit) m_currentMissDecals.insert(0, newDecal);	// Add the new decal to the front of the Array (if a miss)
+	if (!hit) {
+		m_currentMissDecals.insert(0, newDecal);	// Add the new decal to the front of the Array (if a miss)
+		m_missDecalTimesRemaining.insert(0, m_config->missDecalTimeoutS);
+	}
 	else {
 		m_hitDecal = newDecal;
 		m_hitDecalTimeRemainingS = m_config->hitDecalDurationS;
@@ -310,10 +328,12 @@ void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 }
 
 void Weapon::clearDecals(bool clearHitDecal) {
-	while (m_currentMissDecals.size() > 0) {
+	while (m_currentMissDecals.size() > 0) {				// Remove and clear miss decals
 		m_scene->remove(m_currentMissDecals.pop());
 	}
-	if (clearHitDecal && notNull(m_hitDecal)) {
+	m_missDecalTimesRemaining.clear();						// Clear miss decal timeouts
+
+	if (clearHitDecal && notNull(m_hitDecal)) {				// Clear hit decal (if one is present)
 		m_scene->remove(m_hitDecal);
 	}
 }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -94,6 +94,7 @@ public:
 	String	hitDecal = "";												///< The decal to place where the shot hits
 	int		missDecalCount = 2;											///< Number of miss decals to draw
 	float	missDecalScale = 1.0f;										///< Scale to apply to the miss decal
+	float	missDecalTimeoutS = -1;										///< Miss decals don't timeout by default
 	bool	clearTrialMissDecals = true;								///< Clear the miss decals after each trial
 	float	hitDecalScale = 1.0f;										///< Scale to apply to the hit decal
 	float	hitDecalDurationS = 0.1f;									///< Duration to show the hit decal for (in seconds)
@@ -154,6 +155,7 @@ protected:
 	shared_ptr<VisibleEntity>				m_hitDecal;							///< Pointer to hit decal
 	RealTime								m_hitDecalTimeRemainingS = 0.f;		///< Remaining duration to show the decal for
 	Array<shared_ptr<VisibleEntity>>		m_currentMissDecals;				///< Pointers to miss decals
+	Array<SimTime>							m_missDecalTimesRemaining;				///< Create times for miss decals
 
 	Random									m_rand;
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -94,6 +94,7 @@ public:
 	String	hitDecal = "";												///< The decal to place where the shot hits
 	int		missDecalCount = 2;											///< Number of miss decals to draw
 	float	missDecalScale = 1.0f;										///< Scale to apply to the miss decal
+	bool	clearTrialMissDecals = true;								///< Clear the miss decals after each trial
 	float	hitDecalScale = 1.0f;										///< Scale to apply to the hit decal
 	float	hitDecalDurationS = 0.1f;									///< Duration to show the hit decal for (in seconds)
 	float	hitDecalColorMult = 2.0f;									///< "Encoding" field (aka color multiplier) for hit decal
@@ -229,7 +230,7 @@ public:
 
 	void simulateProjectiles(SimTime sdt, const Array<shared_ptr<TargetEntity>>& targets, const Array<shared_ptr<Entity>>& dontHit = {});
 	void drawDecal(const Point3& point, const Vector3& normal, bool hit = false);
-	void clearDecals();
+	void clearDecals(bool clearHitDecal = true);
 	void loadDecals();
 	void loadModels();
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -97,7 +97,7 @@ public:
 	float	missDecalTimeoutS = -1;										///< Miss decals don't timeout by default
 	bool	clearTrialMissDecals = true;								///< Clear the miss decals after each trial
 	float	hitDecalScale = 1.0f;										///< Scale to apply to the hit decal
-	float	hitDecalDurationS = 0.1f;									///< Duration to show the hit decal for (in seconds)
+	float	hitDecalTimeoutS = 0.1f;									///< Duration to show the hit decal for (in seconds)
 	float	hitDecalColorMult = 2.0f;									///< "Encoding" field (aka color multiplier) for hit decal
 
 	float	fireSpreadDegrees = 0;										///< The spread of the fire


### PR DESCRIPTION
This branch adds:

- A quick fix for the `Weapon::clearDecals()` call that removes decals from the scene
- A new `clearTrialMissDecals` weapon config flag (defaults to `true`) that allows experiment designers to choose whether miss decals are removed at the start of a new trial
- A new `missDecalTimeoutS` weapon config parameter (default to `-1` for no timeout) that allows experiment designers to set a (simulation time-based) timeout for miss decals