### PR TITLE
Logger null check in Session::processResponse()

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -112,7 +112,7 @@ void FPSciApp::closeUserSettingsWindow() {
 void FPSciApp::saveUserConfig(bool onDiff) {
 	// Check for save on diff, without mismatch
 	if (onDiff && m_lastSavedUser == *currentUser()) return;
-	if (sess->logger) {
+	if (notNull(sess->logger)) {
 		sess->logger->logUserConfig(*currentUser(), sessConfig->id, sessConfig->player.turnScale);
 	}
 	userTable.save(startupConfig.experimentList[experimentIdx].userConfigFilename);

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -690,7 +690,7 @@ String Session::getFeedbackMessage() {
 }
 
 void Session::endLogging() {
-	if (logger != nullptr) {
+	if (notNull(logger)) {
 
 		//m_logger->logUserConfig(*m_app->currentUser(), m_config->id, m_config->player.turnScale);
 		logger->flush(false);

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -310,7 +310,9 @@ void Session::processResponse()
 		m_remainingTrials[m_currTrialIdx] -= 1;	
 	}
 
-	logger->updateSessionEntry((m_remainingTrials[m_currTrialIdx] == 0), m_completedTrials[m_currTrialIdx]);			// Update session entry in database
+	if (notNull(logger)) {
+		logger->updateSessionEntry((m_remainingTrials[m_currTrialIdx] == 0), m_completedTrials[m_currTrialIdx]);			// Update session entry in database
+	}
 
 	// Check for whether all targets have been destroyed
 	if (m_destroyedTargets == totalTargets) {


### PR DESCRIPTION
Quick null check addition to prevent crash in `Session::processResponse()`

Merging this PR closes #294.