### PR TITLE
Add loopFireSound parameter to weapon

### DIFF
--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -46,6 +46,7 @@ Controls specific to the sound/view model for the weapon are provided below:
 |-----------------------|-----------|-----------------------------------------------------------------------------------------------------------|
 |`fireSound`            |file       | The filename/location of the audio clip to use for the weapon firing (for no sound use an empty string)   |
 |`fireSoundVol`         |ratio      | The volume to play the `fireSound` clip with                                                              |
+|`loopFireSound`        |`bool`     | Whether or not to loop the `fireSound` clip for non-continuous weapons (weapon must be auto to apply)     |
 |`renderModel`          |`bool`     | Whether or not a weapon model is rendered in the first-person view                                        |
 |`modelSpec`            |`ArticulatedModel::Specification` | Any-based specification for the weapon being used                                  |
 |`kickAngleDegrees`     |`float`    | The angle (in degrees) the weapon model should kick after fire                                            |
@@ -54,6 +55,7 @@ Controls specific to the sound/view model for the weapon are provided below:
 ```
     "fireSound" : "sound/fpsci_fire_100ms.wav"          // This comes w/ FPSci
     "fireSoundVol" : 1.0;       // Play the fire sound at 1/2 volume
+    "loopFireSound": false;     // Don't loop fire sound by default
     "renderModel" : false;      // Don't render a weapon model
     "modelSpec" : [];           // No default model spec provided (see the example config below for more info)
     "kickAngleDegrees": 0;      // Weapons don't kick by default
@@ -143,6 +145,7 @@ The config below provides an example for each of the fields above (along with th
 
 "fireSound": "sound/fpsci_fire_100ms.wav",       // The sound to fire
 "fireSoundVol": 1.0f,
+"loopFireAudio": false,     // Don't loop fire audio  by default
 "renderModel": true,        // Default is false,
 "modelSpec": ArticulatedModel::Specification{			        // Default model
 	filename = "model/sniper/sniper.obj";

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -421,22 +421,17 @@ shared_ptr<TargetEntity> Weapon::fire(
 }
 
 void Weapon::playSound(bool shotFired, bool shootButtonUp) {
-	if (m_config->loopAudio()) {
-		if (notNull(m_fireAudio)) {
-			if (shootButtonUp) {
-				m_fireAudio->setPaused(true);											// Pause looped audio on mouse up
-			}
-			else if (shotFired && m_fireAudio->paused()) {
-				if (m_config->isContinuous()) m_fireAudio->setPaused(false);			// Handle laser case (can just un-pause)
-				else m_fireAudio = m_fireSound->play(m_config->fireSoundVol);			// For loopFireSound case start a new sound here
-			}
+	if (m_config->loopAudio()){											// Continuous weapon/looped audio
+		if (notNull(m_fireAudio) && shootButtonUp) {					// Sound is playing and mouse is up
+			m_fireAudio->stop();										// Stop looped audio on mouse up
+			m_fireAudio = nullptr;
 		}
-		else if (shotFired && notNull(m_fireSound)) {
-			m_fireAudio = m_fireSound->play(m_config->fireSoundVol);
+		else if (shotFired && isNull(m_fireAudio)) {					// Shots fired and sound isn't playing
+			m_fireAudio = m_fireSound->play(m_config->fireSoundVol);	// Start a new sound
 		}
 	}
-	else if (shotFired && notNull(m_fireSound)) {
-		m_fireSound->play(m_config->fireSoundVol);
+	else if (shotFired && notNull(m_fireSound)) {						// Discrete weapon (no looped audio)
+		m_fireAudio = m_fireSound->play(m_config->fireSoundVol);		// Start a new sound
 	}
 }
 

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -15,6 +15,7 @@ WeaponConfig::WeaponConfig(const Any& any) {
 		reader.getIfPresent("damagePerSecond", damagePerSecond);
 		reader.getIfPresent("fireSound", fireSound);
 		reader.getIfPresent("fireSoundVol", fireSoundVol);
+		reader.getIfPresent("loopFireSound", loopFireSound);
 		reader.getIfPresent("hitScan", hitScan);
 
 		reader.getIfPresent("renderModel", renderModel);
@@ -72,6 +73,7 @@ Any WeaponConfig::toAny(const bool forceAll) const {
 	if (forceAll || def.damagePerSecond != damagePerSecond)				a["damagePerSecond"] = damagePerSecond;
 	if (forceAll || def.fireSound != fireSound)							a["fireSound"] = fireSound;
 	if (forceAll || def.fireSoundVol != fireSoundVol)					a["fireSoundVol"] = fireSoundVol;
+	if (forceAll || def.loopFireSound != loopFireSound)					a["loopFireSound"] = loopFireSound;
 	if (forceAll || def.hitScan != hitScan)								a["hitScan"] = hitScan;
 
 	if (forceAll || def.renderModel != renderModel)						a["renderModel"] = renderModel;
@@ -419,13 +421,14 @@ shared_ptr<TargetEntity> Weapon::fire(
 }
 
 void Weapon::playSound(bool shotFired, bool shootButtonUp) {
-	if (m_config->isContinuous()) {
+	if (m_config->loopAudio()) {
 		if (notNull(m_fireAudio)) {
 			if (shootButtonUp) {
-				m_fireAudio->setPaused(true);
+				m_fireAudio->setPaused(true);											// Pause looped audio on mouse up
 			}
 			else if (shotFired && m_fireAudio->paused()) {
-				m_fireAudio->setPaused(false);
+				if (m_config->isContinuous()) m_fireAudio->setPaused(false);			// Handle laser case (can just un-pause)
+				else m_fireAudio = m_fireSound->play(m_config->fireSoundVol);			// For loopFireSound case start a new sound here
 			}
 		}
 		else if (shotFired && notNull(m_fireSound)) {

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -76,6 +76,7 @@ public:
 	float	damagePerSecond = 2.0f;										///< Damage per second delivered (compute shot damage as damagePerSecond/firePeriod)
 	String	fireSound = "sound/fpsci_fire_100ms.wav"; 					///< Sound to play on fire
 	float	fireSoundVol = 1.0f;										///< Volume for fire sound
+	bool	loopFireSound = false;											///< Loop weapon audio (override for auto fire weapons)
 	bool	renderModel = false;										///< Render a model for the weapon?
 	bool	hitScan = true;												///< Is the weapon a projectile or hitscan
 
@@ -114,6 +115,7 @@ public:
 
 	/** Returns true if firePeriod == 0 and autoFire == true */
 	inline bool isContinuous() const { return firePeriod == 0 && autoFire; }
+	inline bool loopAudio() const { return isContinuous() || (loopFireSound && autoFire); }
 
 	WeaponConfig() {}
 	WeaponConfig(const Any& any);
@@ -214,7 +216,7 @@ public:
 	void loadSounds() {
 		// Check for play mode specific parameters
 		if (notNull(m_fireAudio)) { m_fireAudio->stop(); }
-		if(!m_config->fireSound.empty()) m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->isContinuous());
+		if(!m_config->fireSound.empty()) m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->loopAudio());
 		else { m_fireSound = nullptr; }
 	}
 	// Plays the sound based on the weapon fire mode


### PR DESCRIPTION
This branch adds support for a weapon config `loopFireSound` parameter that can be set to `true` (default is `false`) to enable looped audio playback for automatic, but not continuously firing, weapons. Continuously firing weapons (i.e. lasers) have always used looped audio in FPSci.