### PR TITLE
Fix for spawning destination targets at their first destination

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -277,7 +277,7 @@ void Session::spawnTrialTargets(Point3 initialSpawnPos, bool previewMode) {
 		// Check for case w/ destination array
 		shared_ptr<TargetEntity> t;
 		if (target->destinations.size() > 0) {
-			Point3 offset = isWorldSpace ? Point3(0.0, 0.0, 0.0) : f.pointToWorldSpace(Point3(0, 0, -m_targetDistance));
+			Point3 offset = isWorldSpace ? target->destinations[0].position : f.pointToWorldSpace(Point3(0, 0, -m_targetDistance));
 			t = spawnDestTarget(target, offset, spawnColor, i, name);
 		}
 		// Otherwise check if this is a jumping target


### PR DESCRIPTION
This branch adds support for an issue in which destination targets are not spawned at the correct location initially. The primary intent of this fix is allowing a simple world-space static target to be created using a single-point destinations array (as opposed to a world-space parametrized target with a zero width spawn bounding box):

```
targets = [
        {
            id = "point"; destSpace = "world";     
            destinations = [{ t: 0, xyz: Point3(38.75, -1.3, 0.7)}];
        }
...
];
```

It's reasonable to assume this bug also impacts destination-based targets with more than a single destination that rely on the target to spawn at their first position rather than (0,0,0) initially

Merging this PR closes #297 