### PR TITLE
Cache session shaders manually to work around LAUNCH_SHADER assumption

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1124,7 +1124,10 @@ void FPSciApp::onPostProcessHDR3DEffects(RenderDevice *rd) {
             args.setUniform("iMouse", userInput->mouseXY());
             args.setUniform("iFrame", frameNumber);
 			args.setRect(rd->viewport());
-			LAUNCH_SHADER(sessConfig->render.shader, args);
+			if (!m_shaderToyTable.containsKey(sessConfig->render.shader)) {
+				m_shaderToyTable.set(sessConfig->render.shader, G3D::Shader::getShaderFromPattern(sessConfig->render.shader) );
+			}
+			LAUNCH_SHADER_PTR(m_shaderToyTable[sessConfig->render.shader], args);
 			lastTime = iTime;
 		} rd->pop2D();
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -554,6 +554,10 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 		m_sceneHitSound = Sound::create(System::findDataFile(sessConfig->audio.sceneHitSound));
 	}
 
+	// Update shader table
+	m_shaderToyTable.clear();
+	m_shaderToyTable.set(sessConfig->render.shader, G3D::Shader::getShaderFromPattern(sessConfig->render.shader));
+
 	// Load static HUD textures
 	for (StaticHudElement element : sessConfig->hud.staticElements) {
 		hudTextures.set(element.filename, Texture::fromFile(System::findDataFile(element.filename)));
@@ -1102,7 +1106,7 @@ void FPSciApp::onPostProcessHDR3DEffects(RenderDevice *rd) {
 			}
 		}rd->pop2D();
 	}
-	if (sessConfig->render.shader != "") {
+	if (sessConfig->render.shader != "" && m_shaderToyTable.containsKey(sessConfig->render.shader)) {
 		// Copy the post-VFX HDR (input) framebuffer
 		static shared_ptr<Framebuffer> input = Framebuffer::create(Texture::createEmpty("FPSci::3DShaderPass::iChannel0", m_framebuffer->width(), m_framebuffer->height(), m_framebuffer->texture(0)->format()));
 		m_framebuffer->blitTo(rd, input, false, false, false, false, true);
@@ -1124,9 +1128,6 @@ void FPSciApp::onPostProcessHDR3DEffects(RenderDevice *rd) {
             args.setUniform("iMouse", userInput->mouseXY());
             args.setUniform("iFrame", frameNumber);
 			args.setRect(rd->viewport());
-			if (!m_shaderToyTable.containsKey(sessConfig->render.shader)) {
-				m_shaderToyTable.set(sessConfig->render.shader, G3D::Shader::getShaderFromPattern(sessConfig->render.shader) );
-			}
 			LAUNCH_SHADER_PTR(m_shaderToyTable[sessConfig->render.shader], args);
 			lastTime = iTime;
 		} rd->pop2D();

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -59,6 +59,8 @@ protected:
 	Array<shared_ptr<UniversalMaterial>>	m_materials;						///< This stores the color materials
 
 	Table<String, Array<shared_ptr<ArticulatedModel>>> m_explosionModels;
+	/** table of shaders cached for the 2D shader parameters set per session */
+	Table<String, shared_ptr<G3D::Shader>> m_shaderToyTable;
 
 	/** Used for visualizing history of frame times. Temporary, awaiting a G3D built-in that does this directly with a texture. */
 	Queue<float>							m_frameDurationQueue;				///< Queue for history of frame times


### PR DESCRIPTION
The G3D `LAUNCH_SHADER` macro has a `static` variable inside, assuming the same shader will be provided every time that macro is used. This PR switches to the `LAUNCH_SHADER_PTR` macro that allows us to control shader loading and caching explicitly.

Fixes a bug where sessions with different custom shaders would always use whichever shader was loaded first.