### PR TITLE
Disable crouch/jump as default (if unspecified)

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -183,8 +183,8 @@ allSessionsCompleteFeedback: "All Sessions Complete!",
 "playerAxisLock": [false, false, false],    // Don't lock player motion in any axis
 "turnScale": Vector2(1.0, 1.0),             // Turn rate scaling
 "playerHeight":  1.5,                       // Normal player height
-"crouchHeight": 0.8,                        // Crouch height
-"jumpVelocity": 3.5,                        // Jump velocity
+"crouchHeight": 1.5,                        // Crouch height (no crouch by default)
+"jumpVelocity": 0.0,                        // Jump velocity (no jump by default)
 "jumpInterval": 0.5,                        // Minimum jump interval
 "jumpTouch": true,                          // Require touch for jump
 "playerGravity": Vector3(0.0, -10.0, 0.0),  // Player gravity

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -40,8 +40,8 @@ public:
 	// View parameters
 	float           moveRate = 0.0f;							///< Player move rate (defaults to no motion)
 	float           height = 1.5f;								///< Height for the player view (in walk mode)
-	float           crouchHeight = 0.8f;						///< Height for the player view (during crouch in walk mode)
-	float           jumpVelocity = 3.5f;						///< Jump velocity for the player
+	float           crouchHeight = 1.5f;						///< Height for the player view (during crouch in walk mode)
+	float           jumpVelocity = 0.0f;						///< Jump velocity for the player
 	float           jumpInterval = 0.5f;						///< Minimum time between jumps in seconds
 	bool            jumpTouch = true;							///< Require the player to be touch a surface to jump?
 	Vector3         gravity = Vector3(0.0f, -10.0f, 0.0f);		///< Gravity vector


### PR DESCRIPTION
This branch sets the configuration default (unspecified values) of `crouchHeight` to `playerHeight` (i.e. no crouch) and `jumpVelocity` to 0 (i.e. no jump) so that these do not need to be explicitly disabled in future experiments that don't desire player motion.

This mirrors the default `moveRate` value of 0 (i.e. no motion by default).