### PR TITLE
Add support for question response order randomization

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -234,6 +234,7 @@ Questions are configured on a per experiment/session basis using the `questions`
 |`optionKeys`           |`Array<GKey>`  | An array of `GKey` options in 1:1 correspondence with `options` above. Leave empty for no keybinds. Check [here](keymap.md#gkey-string) for strings to use for `GKey`s. |
 |`fullscreen`           |`bool`  | When set this opens the dialog in "fullscreen" mode, overlaying all of the rendered content (default is `false`) |
 |`showCursor`           |`bool`  | Allows the experiment designer to hide the cursor while responding to this dialog (default is `true`). Best used with `optionKeys` set otherwise there may be no way to answer the question. Not intended for use with `"Entry"` question types. |
+|`randomOrder`          |`bool`  | Randomize the option order for `MultipleChoice` and `Rating` questions optionally    |
 
 The user can specify one or more questions using the `questions` array, as demonstrated below.
 
@@ -251,6 +252,7 @@ The user can specify one or more questions using the `questions` array, as demon
         "optionKeys" : ["A", "B", "C"],
         "fullscreen": true,
         "showCursor" : false,
+        "randomOrder": false
     }
 ]
 ```

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -391,6 +391,7 @@ void FPSciApp::presentQuestion(Question question) {
 	if (notNull(dialog)) removeWidget(dialog);		// Remove the current dialog widget (if valid)
 	currentQuestion = question;						// Store this for processing key-bound presses
 	Array<String> options = question.options;		// Make a copy of the options (to add key binds if necessary)
+	if (question.randomOrder) options.randomize();
 	const Rect2D windowRect = window()->clientRect();
 	const Point2 size = question.fullscreen ? Point2(windowRect.width(), windowRect.height()) : Point2(400, 200);
 	switch (question.type) {

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -472,6 +472,7 @@ Question::Question(const Any& any) {
 		reader.getIfPresent("title", title);
 		reader.getIfPresent("fullscreen", fullscreen);
 		reader.getIfPresent("showCursor", showCursor);
+		reader.getIfPresent("randomOrder", randomOrder);
 
 		// Handle (optional) key binds for options (if provided)
 		if (type == Type::Rating || type == Type::MultipleChoice) {

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -268,13 +268,14 @@ public:
 	};
 
 	Type type = Type::None;
-	String prompt = "";
-	Array<String> options;
-	Array<GKey> optionKeys;
-	String title = "Feedback";
-	String result = "";
-	bool fullscreen = false;
-	bool showCursor = true;
+	String prompt = "";					///< Text display to prompt the user for a response
+	Array<String> options;				///< List of options provided (if multiple choice)
+	Array<GKey> optionKeys;				///< Keys corresponding to the options provided (if multiple choice/ranking)
+	String title = "Feedback";			///< Title of the window displayed (if not fullscreen)
+	String result = "";					///< Reported result (not specified as configuration)
+	bool fullscreen = false;			///< Show this question as fullscreen?
+	bool showCursor = true;				///< Show cursor during question response window (allow clicking for selection)?
+	bool randomOrder = true;			///< Randomize question response order?
 
 	Question() {};
 	Question(const Any& any);


### PR DESCRIPTION
This branch adds support for a `randomOrder` flag specified per question that allows randomized shuffling of `MultipleChoice` and `Rating` question options at presentation time. This is intended to reduce bias in presenting options in the same order repeatedly.