### PR TITLE
Add support for random in range `pretrialDuration`

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -57,7 +57,8 @@ The following settings allow the user to control various timings/durations aroun
 | Parameter Name                |Units              | Description                                                        |
 |-------------------------------|-------------------|--------------------------------------------------------------------|
 |`clickToStart`                 |`bool`             |Require the user to click at the start of the session to spawn the first reference target  |
-|`pretrialDuration`             |s (or `Array<`s`>`)  |The time before the start of each trial (or a randomized range)     |
+|`pretrialDuration`             |s                  |The time before the start of each trial (or the mean of this time if `pretrialDurationRange` is specified    |
+|`pretrialDurationRange`        |`Array<`s`>`       |A [min, max] array over which the pretrial duration will be randomized (according to a truncated exponential distribution) |
 |`maxTrialDuration`             |s                  |The maximum time over which the task can occur                      |
 |`trialFeedbackDuration`        |s                  |The duration of the feedback window between trials                  |
 |`sessionFeedbackDuration`      |s                  |The duration of the feedback window between sessions                |
@@ -67,12 +68,15 @@ The following settings allow the user to control various timings/durations aroun
 ```
 "clickToStart : true,                       // Require a click to start the session
 "pretrialDuration": 0.5,                    // Time allocated for preparing for trial
+"pretrialDurationRange": [0.5, 0.5]         // Default is a non-randomized pretrial duration of 0.5s (do not need to specify this for non-random ranges)
 "maxTrialDuration": 100000.0,               // Maximum duration allowed for completion of the task
 "trialFeedbackDuration": 1.0,               // Time for user feedback between trials
 "sessionFeedbackDuration": 5.0,             // Time for user feedback between sessions
 "sessionFeedbackRequireClick" : false,      // Don't require a click to move past the scoreboard
 "defaultTrialCount" : 5,
 ```
+
+*Note:* If you are specifying `pretrialDurationRange` to create a truncated exponential range of pretrial duration we *highly* recommend keeping the `pretrialDuration` (i.e. mean value) to less than the mid-point of the `pretrialDurationRange`, skewing the distribution towards the minimum pretrial duration. Skewing this distribution towards the maximum pretrial duration has been demonstrated to produce confounding effects in reaction time studies (makes time at which to react more predictable)!
 
 ## Feedback Configuration
 In addition to the trial/session feedback duration control, the formatting and strings used for feedback are also configurable.

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -54,22 +54,22 @@ The `weapon` config should be thought of as an atomic type (just like an `int` o
 ## Duration Settings
 The following settings allow the user to control various timings/durations around the session state machine.
 
-| Parameter Name                |Units  | Description                                                        |
-|-------------------------------|-------|--------------------------------------------------------------------|
-|`clickToStart`                 |`bool` |Require the user to click at the start of the session to spawn the first reference target  |
-|`pretrialDuration`             |s      |The time before the start of each trial                             |
-|`maxTrialDuration`             |s      |The maximum time over which the task can occur                      |
-|`trialFeedbackDuration`        |s      |The duration of the feedback window between trials                  |
-|`sessionFeedbackDuration`      |s      |The duration of the feedback window between sessions                |
-|`sessionFeedbackRequireClick`  |`bool` |Require the user to click to move past the session feedback (in addition to waiting the `sessionFeedbackDuration`)|
-|`defaultTrialCount`            |`int`  |The value to use for trials with no specified `count` settings      |
+| Parameter Name                |Units              | Description                                                        |
+|-------------------------------|-------------------|--------------------------------------------------------------------|
+|`clickToStart`                 |`bool`             |Require the user to click at the start of the session to spawn the first reference target  |
+|`pretrialDuration`             |s (or `Array<`s`>`)  |The time before the start of each trial (or a randomized range)     |
+|`maxTrialDuration`             |s                  |The maximum time over which the task can occur                      |
+|`trialFeedbackDuration`        |s                  |The duration of the feedback window between trials                  |
+|`sessionFeedbackDuration`      |s                  |The duration of the feedback window between sessions                |
+|`sessionFeedbackRequireClick`  |`bool`             |Require the user to click to move past the session feedback (in addition to waiting the `sessionFeedbackDuration`)|
+|`defaultTrialCount`            |`int`              |The value to use for trials with no specified `count` settings      |
 
 ```
-"clickToStart : true,               // Require a click to start the session
-"pretrialDuration": 0.5,            // Time allocated for preparing for trial
-"maxTrialDuration": 100000.0,       // Maximum duration allowed for completion of the task
-"trialFeedbackDuration": 1.0,       // Time for user feedback between trials
-"sessionFeedbackDuration": 5.0,     // Time for user feedback between sessions
+"clickToStart : true,                       // Require a click to start the session
+"pretrialDuration": 0.5,                    // Time allocated for preparing for trial
+"maxTrialDuration": 100000.0,               // Maximum duration allowed for completion of the task
+"trialFeedbackDuration": 1.0,               // Time for user feedback between trials
+"sessionFeedbackDuration": 5.0,             // Time for user feedback between sessions
 "sessionFeedbackRequireClick" : false,      // Don't require a click to move past the scoreboard
 "defaultTrialCount" : 5,
 ```
@@ -300,8 +300,8 @@ Each question in the array is then asked of the user (via an independent time-se
 |`hudFont`              |file   | The font to use (as a `.fnt` file) for the HUD (for available fonts check `%g3d%/data10/common/font` or `%g3d%/G3D10/  data-files/font`). We suggest using a fixed width font (such as `console.fnt`) for HUD elements|
 
 ```
-"showHUD":  true,               // Show the player HUD (banner, ammo, health bar)
-"showBanner":  true,            // Control the banner at the top of the screen (shows time, score, and session % complete)
+"showHUD":  false,              // Show the player HUD (banner, ammo, health bar)
+"showBanner":  false,           // Control the banner at the top of the screen (shows time, score, and session % complete)
 "bannerLargeFontSize": 30.0,    // Large font size to use in the banner (% complete)
 "bannerSmallFontSize": 14.0,    // Small font size to use in the banner (time remaining and score)
 "hudFont": "console.fnt",       // Font to use for the HUD (fixed with highly suggested!)

--- a/docs/resultsFiles.md
+++ b/docs/resultsFiles.md
@@ -121,7 +121,8 @@ The `Trials` table provides more detailed feedback on user performance within ea
 * `block_id`: The ID (index) of the current block being performed within the session (repeats trials)
 * `start_time`: The (wall clock) start time of the trial (useful for affiliating player/target actions)
 * `end_time`: The (wall clock) end time of the trial (useful for affiliating player/target actions)
-* `task_execution_time`: The total time spent in the task state within this trial
+* `pretrial_duration`: The pretrial duration (in seconds) for this trial (useful particularly when randomized in range)
+* `task_execution_time`: The total time spent in the task state within this trial (in seconds)
 * `destroyed_targets`: A count of total targets destroyed within this trial
 * `total_targets`: A count of the total targets to be presented in this trial (if an unlimited number of targets has been specified this value is `-1`).
 

--- a/source/ExperimentConfig.cpp
+++ b/source/ExperimentConfig.cpp
@@ -209,8 +209,8 @@ Any ExperimentConfig::toAny(const bool forceAll) const {
 }
 
 void ExperimentConfig::printToLog() const{
-	logPrintf("\n-------------------\nExperiment Config\n-------------------\nappendingDescription = %s\nscene name = %s\nTrial Feedback Duration = %f\nPretrial Duration = %f\nMax Trial Task Duration = %f\nMax Clicks = %d\n",
-		description.c_str(), scene.name.c_str(), timing.trialFeedbackDuration, timing.pretrialDuration, timing.maxTrialDuration, weapon.maxAmmo);
+	logPrintf("\n-------------------\nExperiment Config\n-------------------\nappendingDescription = %s\nscene name = %s\nTrial Feedback Duration = %f\nPretrial Duration = [%f, %f]\nMax Trial Task Duration = %f\nMax Clicks = %d\n",
+		description.c_str(), scene.name.c_str(), timing.trialFeedbackDuration, timing.pretrialDuration[0], timing.pretrialDuration[1], timing.maxTrialDuration, weapon.maxAmmo);
 	// Iterate through sessions and print them
 	for (int i = 0; i < sessions.size(); i++) {
 		SessionConfig sess = sessions[i];

--- a/source/ExperimentConfig.cpp
+++ b/source/ExperimentConfig.cpp
@@ -210,7 +210,7 @@ Any ExperimentConfig::toAny(const bool forceAll) const {
 
 void ExperimentConfig::printToLog() const{
 	logPrintf("\n-------------------\nExperiment Config\n-------------------\nappendingDescription = %s\nscene name = %s\nTrial Feedback Duration = %f\nPretrial Duration = [%f, %f]\nMax Trial Task Duration = %f\nMax Clicks = %d\n",
-		description.c_str(), scene.name.c_str(), timing.trialFeedbackDuration, timing.pretrialDuration[0], timing.pretrialDuration[1], timing.maxTrialDuration, weapon.maxAmmo);
+		description.c_str(), scene.name.c_str(), timing.trialFeedbackDuration, timing.pretrialDuration, timing.maxTrialDuration, weapon.maxAmmo);
 	// Iterate through sessions and print them
 	for (int i = 0; i < sessions.size(); i++) {
 		SessionConfig sess = sessions[i];

--- a/source/ExperimentConfig.cpp
+++ b/source/ExperimentConfig.cpp
@@ -209,7 +209,7 @@ Any ExperimentConfig::toAny(const bool forceAll) const {
 }
 
 void ExperimentConfig::printToLog() const{
-	logPrintf("\n-------------------\nExperiment Config\n-------------------\nappendingDescription = %s\nscene name = %s\nTrial Feedback Duration = %f\nPretrial Duration = [%f, %f]\nMax Trial Task Duration = %f\nMax Clicks = %d\n",
+	logPrintf("\n-------------------\nExperiment Config\n-------------------\nappendingDescription = %s\nscene name = %s\nTrial Feedback Duration = %f\nPretrial Duration = %f\nMax Trial Task Duration = %f\nMax Clicks = %d\n",
 		description.c_str(), scene.name.c_str(), timing.trialFeedbackDuration, timing.pretrialDuration, timing.maxTrialDuration, weapon.maxAmmo);
 	// Iterate through sessions and print them
 	for (int i = 0; i < sessions.size(); i++) {

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -138,7 +138,7 @@ public:
 class TimingConfig {
 public:
 	// Timing parameters
-	float           pretrialDuration = 0.5f;					///< Time in ready (pre-trial) state in seconds
+	Array<float>    pretrialDuration = { 0.5f, 0.5f };			///< Time in ready (pre-trial) state in seconds
 	float           maxTrialDuration = 100000.0f;				///< Maximum time spent in any one trial task
 	float           trialFeedbackDuration = 1.0f;				///< Time in the per-trial feedback state in seconds
 	float			sessionFeedbackDuration = 2.0f;				///< Time in the session feedback state in seconds

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -138,7 +138,9 @@ public:
 class TimingConfig {
 public:
 	// Timing parameters
-	Array<float>    pretrialDuration = { 0.5f, 0.5f };			///< Time in ready (pre-trial) state in seconds
+	float			pretrialDuration = 0.5f;					///< Time in ready (pre-trial) state in seconds
+	float			pretrialDurationLambda = fnan();			///< Lambda used for pretrial duration truncated exponential randomization
+	Array<float>	pretrialDurationRange = {};					///< Pretrial duration range (if randomized)
 	float           maxTrialDuration = 100000.0f;				///< Maximum time spent in any one trial task
 	float           trialFeedbackDuration = 1.0f;				///< Time in the per-trial feedback state in seconds
 	float			sessionFeedbackDuration = 2.0f;				///< Time in the session feedback state in seconds

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -106,6 +106,7 @@ void FPSciLogger::openResultsFile(const String& filename,
 				{ "block_id", "text"},
 				{ "start_time", "text" },
 				{ "end_time", "text" },
+				{ "pretrial_duration", "real" },
 				{ "task_execution_time", "real" },
 				{ "destroyed_targets", "real" },
 				{ "total_targets", "real" }

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -526,6 +526,7 @@ void Session::recordTrialResponse(int destroyedTargets, int totalTargets)
 			format("'Block %d'", m_currBlock),
 			"'" + m_taskStartTime + "'",
 			"'" + m_taskEndTime + "'",
+			String(std::to_string(m_pretrialDuration)),
 			String(std::to_string(m_taskExecutionTime)),
 			String(std::to_string(destroyedTargets)),
 			String(std::to_string(totalTargets))

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -132,8 +132,9 @@ bool Session::nextCondition() {
 	int idx = Random::common().integer(0, unrunTrialIdxs.size()-1);
 	m_currTrialIdx = unrunTrialIdxs[idx];
 
-	// Produce random in range pretrial duration
-	m_pretrialDuration = Random::common().uniform(m_config->timing.pretrialDuration[0], m_config->timing.pretrialDuration[1]);
+	// Produce (potentially random in range) pretrial duration
+	if (isNaN(m_config->timing.pretrialDurationLambda)) m_pretrialDuration = m_config->timing.pretrialDuration;
+	else m_pretrialDuration = drawTruncatedExp(m_config->timing.pretrialDurationLambda, m_config->timing.pretrialDurationRange[0], m_config->timing.pretrialDurationRange[1]);
 	
 	return true;
 }

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -131,6 +131,10 @@ bool Session::nextCondition() {
 	if (unrunTrialIdxs.size() == 0) return false;
 	int idx = Random::common().integer(0, unrunTrialIdxs.size()-1);
 	m_currTrialIdx = unrunTrialIdxs[idx];
+
+	// Produce random in range pretrial duration
+	m_pretrialDuration = Random::common().uniform(m_config->timing.pretrialDuration[0], m_config->timing.pretrialDuration[1]);
+	
 	return true;
 }
 
@@ -343,7 +347,7 @@ void Session::updatePresentationState()
 	}
 	else if (currentState == PresentationState::pretrial)
 	{
-		if (stateElapsedTime > m_config->timing.pretrialDuration)
+		if (stateElapsedTime > m_pretrialDuration)
 		{
 			newState = PresentationState::trialTask;
 			if (m_config->player.stillBetweenTrials) {

--- a/source/Session.h
+++ b/source/Session.h
@@ -291,6 +291,14 @@ protected:
 		const String& name = ""
 	);
 
+	inline float drawTruncatedExp(float lambda, float min, float max) {
+		const float p = Random::common().uniform();
+		const float R = max - min;
+		if (lambda == 0.f) return min + p * R;
+		if (lambda < -88.f) return max;				// This prevents against numerical errors in the expression below
+		return -log(1 - p * (1 - exp(-lambda * R))) / lambda + min;
+	}
+
 	inline Point2 getViewDirection()
 	{   // returns (azimuth, elevation), where azimuth is 0 deg when straightahead and + for right, - for left.
 		Point3 view_cartesian = m_camera->frame().lookVector();

--- a/source/Session.h
+++ b/source/Session.h
@@ -182,6 +182,7 @@ protected:
 	Array<Array<shared_ptr<TargetConfig>>> m_targetConfigs;	///< Target configurations by trial
 
 	// Time-based parameters
+	float m_pretrialDuration;							///< (Possibly) randomized pretrial duration
 	RealTime m_taskExecutionTime;						///< Task completion time for the most recent trial
 	String m_taskStartTime;								///< Recorded task start timestamp							
 	String m_taskEndTime;								///< Recorded task end timestamp


### PR DESCRIPTION
This branch adds support for random-in-range `pretrialDuration`. This does not break previous configs by allowing experiment designers to specify _either_ a scalar value or a 2-array of values for randomization in range. This array is expected to be formatted `[min value, max value]`.

Exceptions are raised when the specified array is undersize (of length 0 or 1), and warnings are printed to the log when oversized (of length >2).

Merging this PR closes #309.