### PR TITLE
Support for programmable variable frame rate

### DIFF
--- a/docs/AnyFile.md
+++ b/docs/AnyFile.md
@@ -43,7 +43,7 @@ This is an example block comment
 fieldName = [value],            // This is an example line comment
 ```
 
-### Including Other Any Files
+### Including Other Files
 In addition to the constructs described above, the `.Any` specification allows "inlining" of other `.Any` file contents into the structure through use of a C-style `#include` statement as demonstrated below.
 
 ```
@@ -51,6 +51,12 @@ fieldName = #include("[filename].Any")
 ```
 
 This allows `.Any` files to be modularly constructed from files containing sub-sets of their contents. This construct effectively decouples the `.Any` file structure/organization from the parsed contents of a single file and is _very_ convenient when restructuring `.Any` heirarchy for improved organization/readability.
+
+Note that the target of a `#include` directive need not be a `.Any` file, it can be any content that will be parsed correctly within the Any syntax. For example JSON file can always be included as Any is directly compatible with JSON. Alternatively a CSV file can be included to populate an array as demonstrated below:
+
+```
+"myArray" = (#include("array_contents.csv"))        // Include CSV file as the contents of an array
+```
 
 ### Integration with C++
 In addition to the comments and `#include` statements described above, the `.Any` file specification also supports direct inlining of certain C++ style "instructions" into many of its substructures. As an example refer to the [preprocess field](https://casual-effects.com/g3d/G3D10/build/manual/class_g3_d_1_1_articulated_model_1_1_specification.html#details) in the `ArticulatedModel::Specification` which makes use of `ArticulatedModel::Specification::Instruction`s to allow C++-esque transforms of a model file.

--- a/docs/AnyFile.md
+++ b/docs/AnyFile.md
@@ -52,7 +52,7 @@ fieldName = #include("[filename].Any")
 
 This allows `.Any` files to be modularly constructed from files containing sub-sets of their contents. This construct effectively decouples the `.Any` file structure/organization from the parsed contents of a single file and is _very_ convenient when restructuring `.Any` heirarchy for improved organization/readability.
 
-Note that the target of a `#include` directive need not be a `.Any` file, it can be any content that will be parsed correctly within the Any syntax. For example JSON file can always be included as Any is directly compatible with JSON. Alternatively a CSV file can be included to populate an array as demonstrated below:
+Note that the target of a `#include` directive need not be a `.Any` file, it can be any content that will be parsed correctly within the Any syntax. For example JSON file can always be included as Any syntax is a superset of JSON. Alternatively a CSV file can be included to populate an array as demonstrated below:
 
 ```
 "myArray" = (#include("array_contents.csv"))        // Include CSV file as the contents of an array

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -145,7 +145,7 @@ allSessionsCompleteFeedback: "All Sessions Complete!",
 |`horizontalFieldOfView`    |°      | The (horizontal) field of view for the user's display, to get the vertical FoV multiply this by `1 / your display's aspect ratio` (9/16 for common FHD, or 1920x1080)|
 |`frameDelay`               |frames | An (integer) count of frames to delay to control latency           |
 |`frameRate`                |fps/Hz | The (target) frame rate of the display (constant for a given session) for more info see the [Frame Rate Modes section](#Frame-Rate-Modes) below.|
-|`frameTimeArray`           |`Array<float>`| An array of frame times to use instead of `frameRate` if populated, otherwise ignored. |
+|`frameTimeArray`           |`Array<float>`| An array of frame times (in seconds) to use instead of `frameRate` if populated, otherwise ignored. |
 |`randomFrameTime`          |`bool` | Whether to selected items from `frameTimeArray` sequentially, or as a uniform random choice. Ignored if `frameTimeArray` is empty. |
 |`resolution2D`             |`Array<int>`| The resolution to render 2D content at (defaults to window resolution)       |
 |`resolution3D`             |`Array<int>`| The resolution to render 3D content at (defaults to window resolution)       |
@@ -169,7 +169,7 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 "horizontalFieldOfView":  103.0,            // Field of view (horizontal) for the user in degrees
 "frameDelay" : 3,                           // Frame delay (in frames)
 "frameRate" : 60,                           // Frame/update rate (in Hz)
-"frameTimeArray" : [],                      // Array of frame times to use instead of `frameRate` if not empty
+"frameTimeArray" : [],                      // Array of frame times (in seconds) to use instead of `frameRate` if not empty
 "randomFrameTime" : false,                  // Choose items from `frameTimeArray` in order
 
 "resolution2D": [0,0],                      // Use native resolution for 2D by default

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -146,7 +146,8 @@ allSessionsCompleteFeedback: "All Sessions Complete!",
 |`frameDelay`               |frames | An (integer) count of frames to delay to control latency           |
 |`frameRate`                |fps/Hz | The (target) frame rate of the display (constant for a given session) for more info see the [Frame Rate Modes section](#Frame-Rate-Modes) below.|
 |`frameTimeArray`           |`Array<float>`| An array of frame times (in seconds) to use instead of `frameRate` if populated, otherwise ignored. |
-|`randomFrameTime`          |`bool` | Whether to selected items from `frameTimeArray` sequentially, or as a uniform random choice. Ignored if `frameTimeArray` is empty. |
+|`frameTimeRandomize`       |`bool` | Whether to selected items from `frameTimeArray` sequentially, or as a uniform random choice. Ignored if `frameTimeArray` is empty. |
+|`frameTimeMode`            |`String`    | The mode to use for frame time (can be `"always"`, "`taskOnly"`, or `"restartWithTask"`, not case sensitive), see the table in the [Frame Timing Approaches section](#Frame-Timing-Approaches) for more information. |
 |`resolution2D`             |`Array<int>`| The resolution to render 2D content at (defaults to window resolution)       |
 |`resolution3D`             |`Array<int>`| The resolution to render 3D content at (defaults to window resolution)       |
 |`resolutionComposite`      |`Array<int>`| The resolution to render the composite result at (defaults to window resolution)     |
@@ -170,7 +171,8 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 "frameDelay" : 3,                           // Frame delay (in frames)
 "frameRate" : 60,                           // Frame/update rate (in Hz)
 "frameTimeArray" : [],                      // Array of frame times (in seconds) to use instead of `frameRate` if not empty
-"randomFrameTime" : false,                  // Choose items from `frameTimeArray` in order
+"frameTimeRandomize" : false,               // Choose items from `frameTimeArray` in order
+"frameTimeMode": "always",                  // Always apply the desired frame rate/time pattern
 
 "resolution2D": [0,0],                      // Use native resolution for 2D by default
 "resolution3D": [0,0],                      // Use native resolution for 3D by default
@@ -646,3 +648,17 @@ The `frameRate` parameter in any given session config can be used in 3 different
 * If the `frameRate` parameter is set to a value >> refresh rate of the display (we suggest `8192fps`), then the program runs in "unlocked" mode wherein as many frames as can be drawn are rendered per displayed frame. This is the common mode of operation in many modern games.
 * If the `frameRate` parameter is set close to the refresh rate of the display then the programs runs in "fixed" frame rate mode, wherein the drawn frames are limited to the rate provided
 * If `frameRate = 0` then this indicates "default" mode, wherein the default frame rate settings for the window are applied. This should be equivalent to the "unlocked" mode for most systems. This is the default setting if you do not specify a frame rate in the file.
+
+## Frame Timing Approaches
+The following table details various frame timing approaches that can be configured within FPSci.
+
+|Frame timing approach                                          |`frameTimeMode`    |Result                                         | 
+|---------------------------------------------------------------|-------------------|-----------------------------------------------|
+|Specified using `frameRate` parameter (Empty `frameTimeArray`) |Don't Care         |Always apply the specified `frameRate`         |
+|Ordered timing sequence specified with `frameTimeArray` and `frameTimeRandomize` = `False`     |`always`           |Continuously cycle through the `frameTimeArray` regardless of experiment state, wrap around when complete|
+|                                                               |`taskOnly`         |Only cycle through the `frameTimeArray` during the task state (use specified `frameRate` elsewhere), but do not restart from the beginning of the `frameTimeArray` in each trial|
+|                                                               |`restartWithTask`  |Cycle through the `frameTimeArray` during the task state (use specified `frameRate` eslsewhere) and restart from the beginning of the `frameTimeArray` at the start of each trial|
+|Randomized timing distribution specified with `frameTimeArray` and `frameTimeRandomize` = `True` | `always`     |Always pick a random value from the `frameTimeArray` for frame timing |
+|                                                               |`taskOnly` or `restartWithTask`  |Only pick random values for frame time during the task state (use specified `frameRate` elsewhere) |
+
+Note: To specify just 2 frame rates (one in task and one elsewhere) specify a `frameTimeArray` of length 1 (the desired in-task frame time), set `frameTimeMode` to `"taskOnly"` (or `"restartWithTask"`) and use the `frameRate` parameter to specify the desired frame time in states other than the task.

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -662,3 +662,8 @@ The following table details various frame timing approaches that can be configur
 |                                                               |`taskOnly` or `restartWithTask`  |Only pick random values for frame time during the task state (use specified `frameRate` elsewhere) |
 
 Note: To specify just 2 frame rates (one in task and one elsewhere) specify a `frameTimeArray` of length 1 (the desired in-task frame time), set `frameTimeMode` to `"taskOnly"` (or `"restartWithTask"`) and use the `frameRate` parameter to specify the desired frame time in states other than the task.
+
+Additionally, the `frameTimeArray` can be included using a CSV file and the Any `#include` directive as demonstrated below:
+```
+"frameTimeArray" : (#include("my_frame_time_pattern.csv"))
+```

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -145,6 +145,8 @@ allSessionsCompleteFeedback: "All Sessions Complete!",
 |`horizontalFieldOfView`    |°      | The (horizontal) field of view for the user's display, to get the vertical FoV multiply this by `1 / your display's aspect ratio` (9/16 for common FHD, or 1920x1080)|
 |`frameDelay`               |frames | An (integer) count of frames to delay to control latency           |
 |`frameRate`                |fps/Hz | The (target) frame rate of the display (constant for a given session) for more info see the [Frame Rate Modes section](#Frame-Rate-Modes) below.|
+|`frameTimeArray`           |`Array<float>`| An array of frame times to use instead of `frameRate` if populated, otherwise ignored. |
+|`randomFrameTime`          |`bool` | Whether to selected items from `frameTimeArray` sequentially, or as a uniform random choice. Ignored if `frameTimeArray` is empty. |
 |`resolution2D`             |`Array<int>`| The resolution to render 2D content at (defaults to window resolution)       |
 |`resolution3D`             |`Array<int>`| The resolution to render 3D content at (defaults to window resolution)       |
 |`resolutionComposite`      |`Array<int>`| The resolution to render the composite result at (defaults to window resolution)     |
@@ -167,6 +169,8 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 "horizontalFieldOfView":  103.0,            // Field of view (horizontal) for the user in degrees
 "frameDelay" : 3,                           // Frame delay (in frames)
 "frameRate" : 60,                           // Frame/update rate (in Hz)
+"frameTimeArray" : [],                      // Array of frame times to use instead of `frameRate` if not empty
+"randomFrameTime" : false,                  // Choose items from `frameTimeArray` in order
 
 "resolution2D": [0,0],                      // Use native resolution for 2D by default
 "resolution3D": [0,0],                      // Use native resolution for 3D by default

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1362,14 +1362,14 @@ void FPSciApp::oneFrame() {
 
             SimTime sdt = m_simTimeStep;
             if (sdt == MATCH_REAL_TIME_TARGET) {
-                sdt = m_wallClockTargetDuration;
+                sdt = (SimTime)sess->targetFrameTime();
             }
             else if (sdt == REAL_TIME) {
                 sdt = float(timeStep);
             }
             sdt *= m_simTimeScale;
 
-            SimTime idt = m_wallClockTargetDuration;
+            SimTime idt = (SimTime)sess->targetFrameTime();
 
             onBeforeSimulation(rdt, sdt, idt);
             onSimulation(rdt, sdt, idt);
@@ -1414,7 +1414,7 @@ void FPSciApp::oneFrame() {
 
             debugAssert(m_wallClockTargetDuration < finf());
             // Perform wait for actual time needed
-            RealTime duration = m_wallClockTargetDuration;
+            RealTime duration = sess->targetFrameTime();
             if (!window()->hasFocus() && m_lowerFrameRateInBackground) {
                 // Lower frame rate to 4fps
                 duration = 1.0 / 4.0;

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1298,8 +1298,8 @@ void FPSciApp::oneFrame() {
             RealTime cumulativeTime = nowAfterLoop - m_lastWaitTime;
 
             debugAssert(m_wallClockTargetDuration < finf());
-            // Perform wait for actual time needed
-            RealTime duration = m_wallClockTargetDuration;
+            // Perform wait for target time needed
+            RealTime duration = sess->targetFrameTime();
             if (!window()->hasFocus() && m_lowerFrameRateInBackground) {
                 // Lower frame rate to 4fps
                 duration = 1.0 / 4.0;

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1284,6 +1284,9 @@ void FPSciApp::oneFrame() {
 	// Count this frame (for shaders)
 	m_frameNumber++;
 
+	// Target frame time (only call this method once per one frame!)
+	RealTime targetFrameTime = sess->targetFrameTime();
+
     // Wait
     // Note: we might end up spending all of our time inside of
     // RenderDevice::beginFrame.  Waiting here isn't double waiting,
@@ -1299,7 +1302,7 @@ void FPSciApp::oneFrame() {
 
             debugAssert(m_wallClockTargetDuration < finf());
             // Perform wait for target time needed
-            RealTime duration = sess->targetFrameTime();
+            RealTime duration = targetFrameTime;
             if (!window()->hasFocus() && m_lowerFrameRateInBackground) {
                 // Lower frame rate to 4fps
                 duration = 1.0 / 4.0;
@@ -1362,14 +1365,14 @@ void FPSciApp::oneFrame() {
 
             SimTime sdt = m_simTimeStep;
             if (sdt == MATCH_REAL_TIME_TARGET) {
-                sdt = (SimTime)sess->targetFrameTime();
+                sdt = (SimTime)targetFrameTime;
             }
             else if (sdt == REAL_TIME) {
                 sdt = float(timeStep);
             }
             sdt *= m_simTimeScale;
 
-            SimTime idt = (SimTime)sess->targetFrameTime();
+            SimTime idt = (SimTime)targetFrameTime;
 
             onBeforeSimulation(rdt, sdt, idt);
             onSimulation(rdt, sdt, idt);
@@ -1414,7 +1417,7 @@ void FPSciApp::oneFrame() {
 
             debugAssert(m_wallClockTargetDuration < finf());
             // Perform wait for actual time needed
-            RealTime duration = sess->targetFrameTime();
+            RealTime duration = targetFrameTime;
             if (!window()->hasFocus() && m_lowerFrameRateInBackground) {
                 // Lower frame rate to 4fps
                 duration = 1.0 / 4.0;

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -119,12 +119,27 @@ bool SceneConfig::operator!=(const SceneConfig& other) const {
 }
 
 void RenderConfig::load(AnyTableReader reader, int settingsVersion) {
+	// List of valid frame time modes for parsing from Any
+	const Array<String> validFrameTimeModes = { "always", "taskonly", "restartwithtask" };
+
 	switch (settingsVersion) {
 	case 1:
 		reader.getIfPresent("frameRate", frameRate);
 		reader.getIfPresent("frameDelay", frameDelay);
 		reader.getIfPresent("frameTimeArray", frameTimeArray);
-		reader.getIfPresent("randomFrameTime", randomFrameTime);
+		reader.getIfPresent("frameTimeRandomize", frameTimeRandomize);
+		
+		reader.getIfPresent("frameTimeMode", frameTimeMode);
+		frameTimeMode = toLower(frameTimeMode);	// Convert to lower case
+		if (!validFrameTimeModes.contains(frameTimeMode)) {
+			String errMsg = "Specified \"frameTimeMode\" (\"" + frameTimeMode + "\") is invalid, must be one of: [";
+			for (int i = 0; i < validFrameTimeModes.length(); i++) {
+				errMsg += "\"" + validFrameTimeModes[i] + "\", ";
+			}
+			errMsg = errMsg.substr(0, errMsg.length() - 2) + "]!";
+			throw errMsg;
+		}
+
 		reader.getIfPresent("horizontalFieldOfView", hFoV);
 
 		reader.getIfPresent("resolution2D", resolution2D);
@@ -162,6 +177,9 @@ Any RenderConfig::addToAny(Any a, bool forceAll) const {
 	RenderConfig def;
 	if (forceAll || def.frameRate != frameRate)					a["frameRate"] = frameRate;
 	if (forceAll || def.frameDelay != frameDelay)				a["frameDelay"] = frameDelay;
+	if (forceAll || def.frameTimeArray != frameTimeArray)		a["frameTimeArray"] = frameTimeArray;
+	if (forceAll || def.frameTimeRandomize != frameTimeRandomize) a["frameTimeRandomize"] = frameTimeRandomize;
+	if (forceAll || def.frameTimeMode != frameTimeMode)			a["frameTimeMode"] = frameTimeMode;
 	if (forceAll || def.hFoV != hFoV)							a["horizontalFieldOfView"] = hFoV;
 
 	if (forceAll || def.resolution2D != resolution2D)			a["resolution2D"] = resolution2D;

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -123,6 +123,8 @@ void RenderConfig::load(AnyTableReader reader, int settingsVersion) {
 	case 1:
 		reader.getIfPresent("frameRate", frameRate);
 		reader.getIfPresent("frameDelay", frameDelay);
+		reader.getIfPresent("frameTimeArray", frameTimeArray);
+		reader.getIfPresent("randomFrameTime", randomFrameTime);
 		reader.getIfPresent("horizontalFieldOfView", hFoV);
 
 		reader.getIfPresent("resolution2D", resolution2D);

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -27,6 +27,8 @@ public:
 	// Rendering parameters
 	float           frameRate = 1000.0f;						///< Target (goal) frame rate (in Hz)
 	int             frameDelay = 0;								///< Integer frame delay (in frames)
+	Array<float>	frameTimeArray = { };						///< Array of target frame times (in seconds)
+	bool			randomFrameTime = false;					///< Whether to choose a sequential or random item from frameTimeArray
 	float           hFoV = 103.0f;							    ///< Field of view (horizontal) for the user
 	
 	Array<int>		resolution2D = { 0, 0 };					///< Optional 2D buffer resolution

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -28,7 +28,9 @@ public:
 	float           frameRate = 1000.0f;						///< Target (goal) frame rate (in Hz)
 	int             frameDelay = 0;								///< Integer frame delay (in frames)
 	Array<float>	frameTimeArray = { };						///< Array of target frame times (in seconds)
-	bool			randomFrameTime = false;					///< Whether to choose a sequential or random item from frameTimeArray
+	bool			frameTimeRandomize = false;					///< Whether to choose a sequential or random item from frameTimeArray
+	String			frameTimeMode = "always";					///< Mode to use for frame time selection (can be "always", "taskOnly", or "restartWithTask", case insensitive)
+
 	float           hFoV = 103.0f;							    ///< Field of view (horizontal) for the user
 	
 	Array<int>		resolution2D = { 0, 0 };					///< Optional 2D buffer resolution

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -121,6 +121,29 @@ bool Session::hasNextCondition() const{
 	return false;
 }
 
+const RealTime Session::targetFrameTime()
+{
+	if (m_config->render.frameTimeArray.size() == 0) {
+		// The below matches the functionality in FPSciApp::updateParameters()
+		if (m_config->render.frameRate > 0) {
+			return 1.0f / m_config->render.frameRate;
+		}
+		else {
+			return 1.0f / float(m_app->window()->settings().refreshRate);
+		}
+	}
+	else {
+		if (m_config->render.randomFrameTime) {
+			return m_config->render.frameTimeArray.randomElement();
+		}
+		else {
+			static uint targetIdx = 0;
+			return m_config->render.frameTimeArray[targetIdx++ % m_config->render.frameTimeArray.size()];
+		}
+	}
+	return 0.0;
+}
+
 bool Session::nextCondition() {
 	Array<int> unrunTrialIdxs;
 	for (int i = 0; i < m_remainingTrials.size(); i++) {

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -123,6 +123,8 @@ bool Session::hasNextCondition() const{
 
 const RealTime Session::targetFrameTime()
 {
+	if (!m_hasSession) 	return 1.0f / float(m_app->window()->settings().refreshRate);
+
 	uint arraySize = m_config->render.frameTimeArray.size();
 	if (arraySize > 0) {
 		if (m_config->render.randomFrameTime) {

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -123,25 +123,23 @@ bool Session::hasNextCondition() const{
 
 const RealTime Session::targetFrameTime()
 {
-	if (m_config->render.frameTimeArray.size() == 0) {
-		// The below matches the functionality in FPSciApp::updateParameters()
-		if (m_config->render.frameRate > 0) {
-			return 1.0f / m_config->render.frameRate;
-		}
-		else {
-			return 1.0f / float(m_app->window()->settings().refreshRate);
-		}
-	}
-	else {
+	if (m_config->render.frameTimeArray.size() > 0) {
 		if (m_config->render.randomFrameTime) {
 			return m_config->render.frameTimeArray.randomElement();
 		}
 		else {
 			static uint targetIdx = 0;
-			return m_config->render.frameTimeArray[targetIdx++ % m_config->render.frameTimeArray.size()];
+			return m_config->render.frameTimeArray[targetIdx % m_config->render.frameTimeArray.size()];
+			targetIdx += 1;
+			targetIdx = targetIdx % m_config->render.frameTimeArray.size();
 		}
 	}
-	return 0.0;
+
+	// The below matches the functionality in FPSciApp::updateParameters()
+	if (m_config->render.frameRate > 0) {
+		return 1.0f / m_config->render.frameRate;
+	}
+	return 1.0f / float(m_app->window()->settings().refreshRate);
 }
 
 bool Session::nextCondition() {

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -123,15 +123,16 @@ bool Session::hasNextCondition() const{
 
 const RealTime Session::targetFrameTime()
 {
-	if (m_config->render.frameTimeArray.size() > 0) {
+	uint arraySize = m_config->render.frameTimeArray.size();
+	if (arraySize > 0) {
 		if (m_config->render.randomFrameTime) {
 			return m_config->render.frameTimeArray.randomElement();
 		}
 		else {
 			static uint targetIdx = 0;
-			RealTime targetTime =  m_config->render.frameTimeArray[targetIdx % m_config->render.frameTimeArray.size()];
+			RealTime targetTime =  m_config->render.frameTimeArray[targetIdx % arraySize];
 			targetIdx += 1;
-			targetIdx = targetIdx % m_config->render.frameTimeArray.size();
+			targetIdx = targetIdx % arraySize;
 			return targetTime;
 		}
 	}

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -129,9 +129,10 @@ const RealTime Session::targetFrameTime()
 		}
 		else {
 			static uint targetIdx = 0;
-			return m_config->render.frameTimeArray[targetIdx % m_config->render.frameTimeArray.size()];
+			RealTime targetTime =  m_config->render.frameTimeArray[targetIdx % m_config->render.frameTimeArray.size()];
 			targetIdx += 1;
 			targetIdx = targetIdx % m_config->render.frameTimeArray.size();
+			return targetTime;
 		}
 	}
 

--- a/source/Session.h
+++ b/source/Session.h
@@ -175,6 +175,7 @@ protected:
 	Array<shared_ptr<TargetEntity>> m_unhittableTargets;	///< Array of targets that can't be hit
 
 
+	int m_frameTimeIdx = 0;									///< Frame time index
 	int m_currTrialIdx;										///< Current trial
 	int m_currQuestionIdx = -1;								///< Current question index
 	Array<int> m_remainingTrials;							///< Completed flags

--- a/source/Session.h
+++ b/source/Session.h
@@ -374,6 +374,8 @@ public:
 	bool nextCondition();
 	bool hasNextCondition() const;
 
+	const RealTime targetFrameTime();
+
 	void endLogging();
 
 	/** randomly returns either +1 or -1 **/	


### PR DESCRIPTION
This PR adds support for specifying frame rate variability through one of the following approaches. This PR adds two render parameters, `frameTimeArray` and `randomFrameTime`, both of which are ignored if `frameTimeArray` is empty, which is the default.

* Specify a frame time sequence to follow by placing that sequence in `frameTimeArray` and setting `randomFrameTime = false`.
* Specify a frame time distribution to choose from randomly by placing the list of frame times in `frameTimeArray` and setting `randomFrameTime = true`.
