### PR TITLE
Add `referenceTargetHitSound` to audio config

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -190,10 +190,15 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 |-----------------------|-------|-----------------------------------------------------------------------------------------------------------|
 |`sceneHitSound`        |file   | The sound to play when the scene (not the target) is hit by a weapon (for no sound use an empty string)   |
 |`sceneHitSoundVol`     |ratio  | The volume of the scene hit sound to play                                                                 |
+|`referenceTargetHitSound`|file | Sound to play when the reference target is hit (for no sound use an empty string)                         |  
+|`referenceTargetHitSoundVol`|ratio | The volume of the  reference target hit sound to play                                                 |
+
 
 ```
 "sceneHitSound": "sound/fpsci_miss_100ms.wav",
 "sceneHitSoundVol": 1.0f,
+"referenceTargetHitSound" : "",
+"referenceTargetHitSoundVol": 1.0f,
 ```
 
 ## Player Controls

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -192,6 +192,7 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 |`sceneHitSoundVol`     |ratio  | The volume of the scene hit sound to play                                                                 |
 |`referenceTargetHitSound`|file | Sound to play when the reference target is hit (for no sound use an empty string)                         |  
 |`referenceTargetHitSoundVol`|ratio | The volume of the  reference target hit sound to play                                                 |
+|`referenceTargetPlayFireSound`|`bool`| Whether to play the weapon's fire sound when presenting the reference target                        |
 
 
 ```
@@ -199,7 +200,10 @@ For more information on G3D `Sampler` options refer to [this reference page](htt
 "sceneHitSoundVol": 1.0f,
 "referenceTargetHitSound" : "",
 "referenceTargetHitSoundVol": 1.0f,
+"referenceTargetPlayFireSound": false,
 ```
+
+Note: The sound played when `referenceTargetPlayFireSound` is set to `true` is the weapon's specified `fireSound` (at its `fireSoundVol`). This audio will only be played when the specified fire sound is not looped (i.e., `fireSoundLoop` is `false` and the weapons's `firedPeriod` is > 0 if `autoFire` is set to `true`).
 
 ## Player Controls
 | Parameter Name     |Units | Description                                                                        |

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -572,6 +572,9 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	if (!sessConfig->audio.sceneHitSound.empty()) {
 		m_sceneHitSound = Sound::create(System::findDataFile(sessConfig->audio.sceneHitSound));
 	}
+	if (!sessConfig->audio.refTargetHitSound.empty()) {
+		m_refTargetHitSound = Sound::create(System::findDataFile(sessConfig->audio.refTargetHitSound));
+	}
 
 	// Load static HUD textures
 	for (StaticHudElement element : sessConfig->hud.staticElements) {
@@ -1108,6 +1111,9 @@ void FPSciApp::hitTarget(shared_ptr<TargetEntity> target) {
 	if (target->name() == "reference") {
 		// Handle reference target here
 		sess->destroyTarget(target);
+		if (notNull(m_refTargetHitSound)) {
+			m_refTargetHitSound->play(sessConfig->audio.refTargetHitSoundVol);
+		}
 		destroyedTarget = true;
 		sess->accumulatePlayerAction(PlayerActionType::Nontask, target->name());
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1245,6 +1245,9 @@ void FPSciApp::onUserInput(UserInput* ui) {
 			float hitDist = finf();
 			int hitIdx = -1;
 			shared_ptr<TargetEntity> target = weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit, true);			// Fire the weapon
+			if (sessConfig->audio.refTargetPlayFireSound && !sessConfig->weapon.loopAudio()) {		// Only play shot sounds for non-looped weapon audio (continuous/automatic fire not allowed)
+				weapon->playSound(true, false);			// Play audio here for reference target
+			}
 		}
 	}
 

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -45,7 +45,8 @@ public:
 
 protected:
 	static const int						MAX_HISTORY_TIMING_FRAMES = 360;	///< Length of the history queue for m_frameDurationQueue
-	shared_ptr<Sound>						m_sceneHitSound;					///< Sound for target exploding
+	shared_ptr<Sound>						m_sceneHitSound;					///< Sound for scene collision
+	shared_ptr<Sound>						m_refTargetHitSound;				///< Sound for hitting the reference target
 
 	shared_ptr<GFont>						m_combatFont;						///< Font used for floating combat text
 	Array<shared_ptr<FloatingCombatText>>	m_combatTextList;					///< Array of existing combat text

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -305,6 +305,9 @@ void AudioConfig::load(AnyTableReader reader, int settingsVersion) {
 	case 1:
 		reader.getIfPresent("sceneHitSound", sceneHitSound);
 		reader.getIfPresent("sceneHitSoundVol", sceneHitSoundVol);
+		reader.getIfPresent("referenceTargetHitSound", refTargetHitSound);
+		reader.getIfPresent("referenceTargetHitSoundVol", refTargetHitSoundVol);
+
 		break;
 	default:
 		throw format("Did not recognize settings version: %d", settingsVersion);
@@ -316,6 +319,9 @@ Any AudioConfig::addToAny(Any a, bool forceAll) const {
 	AudioConfig def;
 	if (forceAll || def.sceneHitSound != sceneHitSound)			a["sceneHitSound"] = sceneHitSound;
 	if (forceAll || def.sceneHitSoundVol != sceneHitSoundVol)	a["sceneHitSoundVol"] = sceneHitSoundVol;
+	if (forceAll || def.refTargetHitSound != refTargetHitSound) a["referenceTargetHitSound"] = refTargetHitSound;
+	if (forceAll || def.refTargetHitSoundVol != refTargetHitSoundVol) a["referenceTargetHitSoundVol"] = refTargetHitSoundVol;
+	
 	return a;
 }
 

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -307,6 +307,7 @@ void AudioConfig::load(AnyTableReader reader, int settingsVersion) {
 		reader.getIfPresent("sceneHitSoundVol", sceneHitSoundVol);
 		reader.getIfPresent("referenceTargetHitSound", refTargetHitSound);
 		reader.getIfPresent("referenceTargetHitSoundVol", refTargetHitSoundVol);
+		reader.getIfPresent("referenceTargetPlayFireSound", refTargetPlayFireSound);
 
 		break;
 	default:
@@ -321,6 +322,7 @@ Any AudioConfig::addToAny(Any a, bool forceAll) const {
 	if (forceAll || def.sceneHitSoundVol != sceneHitSoundVol)	a["sceneHitSoundVol"] = sceneHitSoundVol;
 	if (forceAll || def.refTargetHitSound != refTargetHitSound) a["referenceTargetHitSound"] = refTargetHitSound;
 	if (forceAll || def.refTargetHitSoundVol != refTargetHitSoundVol) a["referenceTargetHitSoundVol"] = refTargetHitSoundVol;
+	if (forceAll || def.refTargetPlayFireSound != refTargetPlayFireSound)	a["referenceTargetPlayFireSound"] = refTargetPlayFireSound;
 	
 	return a;
 }

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -132,6 +132,7 @@ public:
 	float			sceneHitSoundVol = 1.0f;							///< Volume to play scene hit sound at
 	String			refTargetHitSound = "";								///< Reference target hit sound (filename)
 	float			refTargetHitSoundVol = 1.0f;						///< Volume to play target hit sound at
+	bool			refTargetPlayFireSound = false;						///< Play the weapon's fire sound when shooting at the reference target
 
 	void load(AnyTableReader reader, int settingsVersion = 1);
 	Any addToAny(Any a, bool forceAll = false) const;

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -128,8 +128,10 @@ public:
 class AudioConfig {
 public:
 	// Sounds
-	String			sceneHitSound = "sound/fpsci_miss_100ms.wav";								///< Sound to play when hitting the scene
-	float			sceneHitSoundVol = 1.0f;
+	String			sceneHitSound = "sound/fpsci_miss_100ms.wav";		///< Sound to play when hitting the scene
+	float			sceneHitSoundVol = 1.0f;							///< Volume to play scene hit sound at
+	String			refTargetHitSound = "";								///< Reference target hit sound (filename)
+	float			refTargetHitSoundVol = 1.0f;						///< Volume to play target hit sound at
 
 	void load(AnyTableReader reader, int settingsVersion = 1);
 	Any addToAny(Any a, bool forceAll = false) const;


### PR DESCRIPTION
This branch adds support for a `referenceTargetHitSound` config parameter (along with a `referenceTargetHitSoundVol` parameter for volume control) to the audio configuration within the FPSci general configuration.

To demonstrate you can add:
```
referenceTargetHitSound = "sound/fpsci_destroy_150ms.wav";
```
to (the top of/any session in) your experiment configuration file. This should automatically play the specified destroy sound for the reference target. Currently the behavior in this branch defaults to no audio for the reference target, but we can change this default value if we'd like.