### PR TITLE
Add `clearMissDecalsWithReference` parameter

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -432,6 +432,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 |`showReferenceTarget`   |`bool`                | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
+|`clearMissDecalsWithReference`|`bool`              | Clear miss decals when the reference target is destroyed                           |
 |`showPreviewTargetsWithReference` |`bool`      | Show a preview of the trial targets (unhittable) with the reference target. Make these targets hittable once the reference is destroyed |
 |`previewTargetColor`   |`Color3`               | Set the color to draw the preview targets with (before they are active)            |
 
@@ -443,6 +444,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 "showReferenceTarget": true,                    // Show a reference target between trials
 "referenceTargetColor": Color3(1.0,1.0,1.0),    // Reference target color (return to "0" view direction)
 "referenceTargetSize": 0.01,                    // This is a size in meters
+"clearMissDecalsWithReference" : false,         // Don't clear the miss decals when the reference target is eliminated
 "showPreviewTargetsWithReference" : false,      // Don't show the preview targets with the reference
 "previewTargetColor" = Color3(0.5, 0.5, 0.5),   // Use gray for preview targets (if they are shown)
 ```

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -427,6 +427,7 @@ void TargetViewConfig::load(AnyTableReader reader, int settingsVersion) {
 		reader.getIfPresent("showReferenceTarget", showRefTarget);
 		reader.getIfPresent("referenceTargetSize", refTargetSize);
 		reader.getIfPresent("referenceTargetColor", refTargetColor);
+		reader.getIfPresent("clearMissDecalsWithReference", clearDecalsWithRef);
 		reader.getIfPresent("showPreviewTargetsWithReference", previewWithRef);
 		reader.getIfPresent("previewTargetColor", previewColor);
 		break;
@@ -457,6 +458,7 @@ Any TargetViewConfig::addToAny(Any a, bool forceAll) const {
 	if (forceAll || def.showRefTarget != showRefTarget)					a["showRefTarget"] = showRefTarget;
 	if (forceAll || def.refTargetSize != refTargetSize)					a["referenceTargetSize"] = refTargetSize;
 	if (forceAll || def.refTargetColor != refTargetColor)				a["referenceTargetColor"] = refTargetColor;
+	if (forceAll || def.clearDecalsWithRef != clearDecalsWithRef)		a["clearMissDecalsWithReference"] = clearDecalsWithRef;
 	if (forceAll || def.previewWithRef != previewWithRef)				a["showPreviewTargetsWithReference"] = previewWithRef;
 	if (forceAll || def.previewColor != previewColor)					a["previewTargetColor"] = previewColor;
 	return a;

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -210,6 +210,7 @@ public:
 	float           refTargetSize = 0.05f;								///< Size of the reference target
 	Color3          refTargetColor = Color3(1.0, 0.0, 0.0);				///< Default reference target color
 
+	bool			clearDecalsWithRef = false;							///< Clear the decals created from the reference target at the start of the task
 	bool			previewWithRef = false;								///< Show preview of per-trial targets with the reference
 	Color3			previewColor = Color3(0.5, 0.5, 0.5);				///< Color to show preview targets in
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -498,6 +498,10 @@ void Session::updatePresentationState()
 		if ((newState == PresentationState::trialTask) || (newState == PresentationState::trialFeedback && hasNextCondition() && m_config->targetView.showRefTarget)) {
 			initTargetAnimation();
 		}
+
+		if (newState == PresentationState::trialTask && m_config->targetView.clearDecalsWithRef) {
+			m_weapon->clearDecals();		// Clear the decals when transitioning into the task state
+		}
 	}
 }
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -499,7 +499,7 @@ void Session::updatePresentationState()
 			initTargetAnimation();
 		}
 
-		if (newState == PresentationState::trialTask && m_config->targetView.clearDecalsWithRef) {
+		if (newState == PresentationState::pretrial && m_config->targetView.clearDecalsWithRef) {
 			m_weapon->clearDecals();		// Clear the decals when transitioning into the task state
 		}
 	}


### PR DESCRIPTION
This branch adds support for a `clearMissDecalsWithReference` parameter that allows the experiment designer to specify whether or not miss decals created while firing at the reference target are cleared when the trial task begins. The parameter defaults to `false` to preserve historical behavior. To enable, add:
```
clearMissDecalsWithReference = true;
```
to your experiment config.