### PR TITLE
Add `showReferenceTargetMissDecals` parameter

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -433,6 +433,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
 |`showPreviewTargetsWithReference` |`bool`      | Show a preview of the trial targets (unhittable) with the reference target. Make these targets hittable once the reference is destroyed |
+|`showReferenceTargetMissDecals`|`bool`         | Show miss decals when the weapon is firing at a reference target?                  |
 |`previewTargetColor`   |`Color3`               | Set the color to draw the preview targets with (before they are active)            |
 
 ```
@@ -444,6 +445,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 "referenceTargetColor": Color3(1.0,1.0,1.0),    // Reference target color (return to "0" view direction)
 "referenceTargetSize": 0.01,                    // This is a size in meters
 "showPreviewTargetsWithReference" : false,      // Don't show the preview targets with the reference
+"showReferenceTargetMissDecals" : true,         // Show miss decals for reference targets
 "previewTargetColor" = Color3(0.5, 0.5, 0.5),   // Use gray for preview targets (if they are shown)
 ```
 

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -428,6 +428,7 @@ void TargetViewConfig::load(AnyTableReader reader, int settingsVersion) {
 		reader.getIfPresent("referenceTargetSize", refTargetSize);
 		reader.getIfPresent("referenceTargetColor", refTargetColor);
 		reader.getIfPresent("showPreviewTargetsWithReference", previewWithRef);
+		reader.getIfPresent("showReferenceTargetMissDecals", showRefDecals);
 		reader.getIfPresent("previewTargetColor", previewColor);
 		break;
 	default:
@@ -458,6 +459,7 @@ Any TargetViewConfig::addToAny(Any a, bool forceAll) const {
 	if (forceAll || def.refTargetSize != refTargetSize)					a["referenceTargetSize"] = refTargetSize;
 	if (forceAll || def.refTargetColor != refTargetColor)				a["referenceTargetColor"] = refTargetColor;
 	if (forceAll || def.previewWithRef != previewWithRef)				a["showPreviewTargetsWithReference"] = previewWithRef;
+	if (forceAll || def.showRefDecals != showRefDecals)					a["showReferenceTargetMissDecals"] = showRefDecals;
 	if (forceAll || def.previewColor != previewColor)					a["previewTargetColor"] = previewColor;
 	return a;
 }

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -210,7 +210,8 @@ public:
 	float           refTargetSize = 0.05f;								///< Size of the reference target
 	Color3          refTargetColor = Color3(1.0, 0.0, 0.0);				///< Default reference target color
 
-	bool			previewWithRef = false;								///< Show preview of per-trial targets with the reference
+	bool			previewWithRef = false;								///< Show preview of per-trial targets with the reference?
+	bool			showRefDecals = true;								///< Show missed shot decals when shooting at the reference target?
 	Color3			previewColor = Color3(0.5, 0.5, 0.5);				///< Color to show preview targets in
 
 	void load(AnyTableReader reader, int settingsVersion = 1);

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -252,9 +252,8 @@ void Session::initTargetAnimation() {
 			spawnTrialTargets(initialSpawnPos, true);		// Spawn all the targets in preview mode
 		}
 
-		if (!m_config->targetView.showRefDecals) {			// If we shouldn't draw decals for reference targets
-			m_weapon->drawsDecals = false;					// Disable drawing decals
-		}
+		// Set weapon decal state to match configuration for reference targets
+		m_weapon->drawsDecals = m_config->targetView.showRefDecals;
 	}
 
 	// Reset number of destroyed targets (in the trial)

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -234,6 +234,7 @@ void Session::initTargetAnimation() {
 		}
 		else {
 			spawnTrialTargets(initialSpawnPos);			// Spawn all the targets normally
+			m_weapon->drawsDecals = true;				// Enable drawing decals
 		}
 	}
 	else { // State is feedback and we are spawning a reference target
@@ -249,6 +250,10 @@ void Session::initTargetAnimation() {
 
 		if (m_config->targetView.previewWithRef) {
 			spawnTrialTargets(initialSpawnPos, true);		// Spawn all the targets in preview mode
+		}
+
+		if (!m_config->targetView.showRefDecals) {			// If we shouldn't draw decals for reference targets
+			m_weapon->drawsDecals = false;					// Disable drawing decals
 		}
 	}
 

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -293,7 +293,7 @@ void Weapon::simulateProjectiles(SimTime sdt, const Array<shared_ptr<TargetEntit
 
 void Weapon::drawDecal(const Point3& point, const Vector3& normal, bool hit) {
 	// End here if we're not drawing decals
-	if (!m_config->renderDecals) return;
+	if (!drawsDecals || !m_config->renderDecals) return;
 	// Don't draw decals for these cases
 	if (!hit && (m_config->missDecalCount == 0 || m_missDecalModel == nullptr)) return;
 	else if (hit && m_hitDecalModel == nullptr) return;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -162,6 +162,8 @@ protected:
 	Random									m_rand;
 
 public:
+	bool drawsDecals = true;		///< Controls whether or not the weapon draws miss decals
+
 	static shared_ptr<Weapon> create(WeaponConfig* config, shared_ptr<Scene> scene, shared_ptr<Camera> cam) {
 		return createShared<Weapon>(config, scene, cam);
 	};


### PR DESCRIPTION
This branch adds a `showReferenceTargetMissDecals` parameter to allow experiment designers to specify whether miss decals should be displayed when firing at the reference target. This parameter defaults to `true` to maintain historical behavior. To disable it, add:
```
showReferenceTargetMissDecals = false;
```
to your experiment config.