### PR TITLE
Use waypointManager null check instead of `waypointEditorMode` parameter

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -280,7 +280,7 @@ void FPSciApp::updateControls(bool firstSession) {
 	if(!firstSession) m_showUserMenu = sessConfig->menu.showMenuBetweenSessions;
 
 	// Update the waypoint manager
-	if (startupConfig.waypointEditorMode) { waypointManager->updateControls(); }
+	if (notNull(waypointManager)) { waypointManager->updateControls(); }
 
 	// Update the player controls
 	bool visible = false;
@@ -345,7 +345,7 @@ void FPSciApp::makeGUI() {
 		debugPane->addButton("Render Controls [1]", this, &FPSciApp::showRenderControls);
 		debugPane->addButton("Player Controls [2]", this, &FPSciApp::showPlayerControls);
 		debugPane->addButton("Weapon Controls [3]", this, &FPSciApp::showWeaponControls);
-		if(startupConfig.waypointEditorMode) debugPane->addButton("Waypoint Manager [4]", waypointManager, &WaypointManager::showWaypointWindow);
+		if(notNull(waypointManager)) debugPane->addButton("Waypoint Manager [4]", waypointManager, &WaypointManager::showWaypointWindow);
 	}debugPane->endRow();
 
 	// Create the user settings window
@@ -820,7 +820,7 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 			updateParameters(sessConfig->render.frameDelay, sessConfig->render.frameRate);
 		}
 
-		if (startupConfig.waypointEditorMode) {
+		if (notNull(waypointManager)) {
 			// Handle highlighting for selected target
 			waypointManager->updateSelected();
 			// Handle player motion recording here
@@ -874,7 +874,7 @@ bool FPSciApp::onEvent(const GEvent& event) {
 				// Do not set foundKey = true to allow shader reloading from GApp::onEvent()
 			}
 			// Waypoint editor only keys
-			else if (startupConfig.waypointEditorMode) {
+			else if (notNull(waypointManager)) {
 				if (keyMap.map["toggleWaypointWindow"].contains(ksym)) {
 					waypointManager->toggleWaypointWindow();
 					foundKey = true;
@@ -914,7 +914,7 @@ bool FPSciApp::onEvent(const GEvent& event) {
 			}
 		}
 		else if (event.type == GEventType::KEY_UP) {
-			if (startupConfig.waypointEditorMode) {
+			if (notNull(waypointManager)) {
 				if (keyMap.map["moveWaypointUp"].contains(ksym)) {
 					waypointManager->moveMask -= Vector3(0.0f, 1.0f, 0.0f);
 					foundKey = true;
@@ -1225,7 +1225,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 
 	for (GKey selectButton : keyMap.map["selectWaypoint"]) {
 		// Check for developer mode editing here, if so set selected waypoint using the camera
-		if (ui->keyDown(selectButton) && startupConfig.developerMode && startupConfig.waypointEditorMode) {
+		if (ui->keyDown(selectButton) && notNull(waypointManager)) {
 			waypointManager->aimSelectWaypoint(activeCamera());
 		}
 	}

--- a/source/FPSciGraphics.cpp
+++ b/source/FPSciGraphics.cpp
@@ -276,7 +276,7 @@ void FPSciApp::draw2DElements(RenderDevice* rd, Vector2 resolution) {
 	updateFPSIndicator(rd, resolution);				// FPS display (faster than the full stats widget)
 
 	// Handle recording indicator
-	if (startupConfig.waypointEditorMode && waypointManager->recordMotion) {
+	if (notNull(waypointManager) && waypointManager->recordMotion) {
 		Draw::point(Point2(0.9f * resolution.x - 15.f * scale, (20.0f + m_debugMenuHeight) * scale), rd, Color3::red(), 10.0f * scale);
 		outputFont->draw2D(rd, "Recording Position", Point2(0.9f * resolution.x, (7.5f + m_debugMenuHeight) * scale), 20.0f * scale, Color3::red());
 	}

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -162,6 +162,7 @@ public:
 		m_paramIdx = paramIdx;
 		m_scaleIdx = scaleIdx;
 		m_isLogged = isLogged;
+		m_destinations = dests;
 		destinationIdx = 0;
 	}
 

--- a/source/WaypointManager.cpp
+++ b/source/WaypointManager.cpp
@@ -194,20 +194,20 @@ shared_ptr<TargetEntity> WaypointManager::spawnDestTargetPreview(
 	// Create the target
 	const String nameStr = name.empty() ? format("destPreview") : name;
 	const int scaleIndex = clamp(iRound(log(size) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
-	const shared_ptr<TargetEntity>& target = TargetEntity::create(dests, nameStr, m_scene, m_app->targetModels[id][scaleIndex], scaleIndex, 0);
+	const shared_ptr<TargetEntity>& target = TargetEntity::create(dests, nameStr, m_app->scene().get(), m_app->targetModels[id][scaleIndex], scaleIndex, 0);
 
 	// Setup (additional) target parameters
 	target->setFrame(dests[0].position);
 	target->setColor(color);
 
 	// Add target to array and scene
-	m_scene->insert(target);
+	m_app->scene()->insert(target);
 	return target;
 }
 
 void WaypointManager::destroyPreviewTarget() {
 	if (isNull(m_previewTarget)) return;
-	m_scene->removeEntity(m_previewTarget->name());
+	m_app->scene()->removeEntity(m_previewTarget->name());
 	m_previewTarget.reset();
 }
 

--- a/source/WaypointManager.h
+++ b/source/WaypointManager.h
@@ -9,7 +9,6 @@ class WaypointDisplay;
 class WaypointManager : ReferenceCountedObject {
 private:
 	FPSciApp* m_app = nullptr;
-	Scene* m_scene = nullptr;
 
 	shared_ptr<WaypointDisplay> m_waypointControls;
 


### PR DESCRIPTION
This branch moves to null checking `waypointManager` rather than using the `waypointEditorMode` parameter from the startup config. The `waypointManager` is only created when `waypointEditorMode` = `true` _and_ `developerMode` = `true` in the startup config.

This prevents an exception from setting `waypointEditorMode` = `true` with `developerMode` = `false` and simplifies our code.

Merging this PR closes #320.