### PR TITLE
Fix for waypoint target motion

### DIFF
--- a/source/TargetEntity.cpp
+++ b/source/TargetEntity.cpp
@@ -219,37 +219,33 @@ void TargetEntity::onSimulation(SimTime absoluteTime, SimTime deltaTime) {
 	if (m_destinations.size() < 2)
 		return;
 
-	if (m_spawnTime == 0) m_spawnTime = absoluteTime;
+	if (m_spawnTime == 0) m_spawnTime = absoluteTime;						// Get a spawn time (if we don't have one already)
 	SimTime time = fmod(absoluteTime-m_spawnTime, getPathTime());			// Compute a local time (modulus the path time)
 	
+	int nextDestIdx = (destinationIdx + 1) % m_destinations.size();			// Get the next destination's index
+
 	// Check if its time to move to the next segment
-	while(time < m_destinations[destinationIdx].time || time >= m_destinations[destinationIdx+1].time) {
-		destinationIdx++;										// Increment the destination index
-		destinationIdx %= m_destinations.size();					// Wrap if time goes over (works well for looped paths)
+	while(time < m_destinations[destinationIdx].time || time >= m_destinations[nextDestIdx].time) {
+		destinationIdx = nextDestIdx;										// Increment the desintation index
+		nextDestIdx = (destinationIdx + 1) % m_destinations.size();			// Update next destination index
 	}
 	
 	// Get the current and next destination index
 	Destination currDest = m_destinations[destinationIdx];
-	Destination nextDest = m_destinations[(destinationIdx + 1) % m_destinations.size()];
+	Destination nextDest = m_destinations[nextDestIdx];
 
 	// Compute the position by interpolating
-	float duration = nextDest.time - currDest.time;			// Get the total time for this "step
-	duration = max(duration, 0.0f);							// In "wrap" case immediately teleport back to start (0 duration step)
-	
-	float prog = 1.0f;										// By default make the "full step"
+	float duration = nextDest.time - currDest.time;			// Get the total time for this "step"
+	float prog = 0.0f;										// Use no progress for the "wrap" case (duration < 0 above)
 	if (duration > 0.0f) {
-		// Handle time "wrap" case here
-		if (nextDest.time < time) {
-			time -= getPathTime();							// Fix the "wrap" math for prog below
-		}
-		prog = (nextDest.time - time) / duration;			// Get the ratio of time in this step completed
+		prog = 1 - ((nextDest.time - time) / duration);		// Get the ratio of time in this step completed
 	}
 	
-	Point3 delta = currDest.position - nextDest.position; 	// Get the delta vector to move along
+	Point3 delta = nextDest.position - currDest.position; 	// Get the delta vector to move along
 	setFrame((prog*delta) + currDest.position + m_offset);	// Set the new positions
 
-	// Set changed time if it moved
-	if (delta != Point3(0.f, 0.f, 0.f) && m_offset != Vector3(0.f, 0.f, 0.f)) {
+	// Set changed time if target moved
+	if (delta != Point3(0.f, 0.f, 0.f)) {
 		m_lastChangeTime = System::time();
 	}
 


### PR DESCRIPTION
This branch adds a fix for waypoint target motion that corrects how targets interpolate between (more) distant waypoints.

Specifically it corrects some issues with the way the (linear) interpolation between waypoints worked previously and adds more descriptive variable names/comments to help indicate what is happening.

This branch also makes a minor change to the conditions under which the target's `m_lastChangeTime` is set.