### PR TITLE
Remove emergencyTurbo mode

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -348,7 +348,7 @@ void FPSciApp::updateControls(bool firstSession) {
 		rect = m_renderControls->rect();
 		removeWidget(m_renderControls);
 	}
-	m_renderControls = RenderControls::create(this, *sessConfig, renderFPS, emergencyTurbo, numReticles, sceneBrightness, theme, MAX_HISTORY_TIMING_FRAMES);
+	m_renderControls = RenderControls::create(this, *sessConfig, renderFPS, numReticles, sceneBrightness, theme, MAX_HISTORY_TIMING_FRAMES);
 	m_renderControls->setVisible(visible);
 	if (!rect.isEmpty()) m_renderControls->setRect(rect);
 	addWidget(m_renderControls);

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -168,7 +168,6 @@ public:
 	shared_ptr<Texture>             reticleTexture;					///< Texture used for reticle
 	Table<String, shared_ptr<Texture>> hudTextures;					///< Textures used for the HUD
 	shared_ptr<GuiTheme>			theme;	
-	bool                            emergencyTurbo = false;			///< Lower rendering quality to improve performance
 
 	FPSciApp(const GApp::Settings& settings = GApp::Settings());
 

--- a/source/FPSciGraphics.cpp
+++ b/source/FPSciGraphics.cpp
@@ -86,10 +86,6 @@ void FPSciApp::onGraphics3D(RenderDevice* rd, Array<shared_ptr<Surface> >& surfa
 
 	pushRdStateWithDelay(rd, m_ldrDelayBufferQueue, m_currentDelayBufferIndex, displayLagFrames);
 
-	scene()->lightingEnvironment().ambientOcclusionSettings.enabled = !emergencyTurbo;
-	playerCamera->filmSettings().setAntialiasingEnabled(!emergencyTurbo);
-	playerCamera->filmSettings().setBloomStrength(emergencyTurbo ? 0.0f : 0.5f);
-
 	// Tone mapping from HDR --> LDR happens at the end of this call (after onPostProcessHDR3DEffects() call)
 	GApp::onGraphics3D(rd, surface);
 
@@ -134,11 +130,11 @@ void FPSciApp::onPostProcessHDR3DEffects(RenderDevice* rd) {
 				rd->push2D(m_hdrShader3DOutput); {
 				// Setup shadertoy-style args
 				Args args;
-					args.setUniform("iChannel0", m_framebuffer->texture(0), sessConfig->render.sampler3D);
-					const float iTime = float(System::time() - m_startTime);
-					args.setUniform("iTime", iTime);
-					args.setUniform("iTimeDelta", iTime - m_lastTime);
-					args.setUniform("iMouse", userInput->mouseXY());
+				args.setUniform("iChannel0", m_framebuffer->texture(0), sessConfig->render.sampler3D);
+				const float iTime = float(System::time() - m_startTime);
+				args.setUniform("iTime", iTime);
+				args.setUniform("iTimeDelta", iTime - m_lastTime);
+				args.setUniform("iMouse", userInput->mouseXY());
 				args.setUniform("iFrame", m_frameNumber);
 				args.setRect(rd->viewport());
 				LAUNCH_SHADER_PTR(m_shaderTable[sessConfig->render.shader3D], args);
@@ -500,7 +496,7 @@ void FPSciApp::drawHUD(RenderDevice *rd, Vector2 resolution) {
 		);
 	}
 
-	if (sessConfig->hud.showBanner && !emergencyTurbo) {
+	if (sessConfig->hud.showBanner) {
 		const shared_ptr<Texture> scoreBannerTexture = hudTextures["scoreBannerBackdrop"];
 		const Point2 hudCenter(resolution.x / 2.0f, sessConfig->hud.bannerVertVisible * scoreBannerTexture->height() * scale.y + debugMenuHeight());
 		Draw::rect2D((scoreBannerTexture->rect2DBounds() * scale - scoreBannerTexture->vector2Bounds() * scale / 2.0f) * 0.8f + hudCenter, rd, Color3::white(), scoreBannerTexture);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -199,7 +199,7 @@ PlayerControls::PlayerControls(SessionConfig& config, std::function<void()> expo
 	moveTo(Vector2(440, 300));
 }
 
-RenderControls::RenderControls(FPSciApp* app, SessionConfig& config, bool& drawFps, bool& turbo, const int numReticles, float& brightness,
+RenderControls::RenderControls(FPSciApp* app, SessionConfig& config, bool& drawFps, const int numReticles, float& brightness,
 	const shared_ptr<GuiTheme>& theme, const int maxFrameDelay, const float minFrameRate, const float maxFrameRate, float width, float height) :
 	GuiWindow("Render Controls", theme, Rect2D::xywh(5,5,width,height), GuiTheme::NORMAL_WINDOW_STYLE, GuiWindow::HIDE_ON_CLOSE), m_app(app)
 {
@@ -223,7 +223,6 @@ RenderControls::RenderControls(FPSciApp* app, SessionConfig& config, bool& drawF
 	auto framePane = pane->addPane("Frame Rate/Delay");
 	framePane->beginRow(); {
 		framePane->addCheckBox("Show FPS", &drawFps);
-		framePane->addCheckBox("Turbo mode", &turbo);
 	}framePane->endRow();
 	framePane->beginRow(); {
 		auto c = framePane->addNumberBox("Framerate", &(config.render.frameRate), "fps", GuiTheme::LINEAR_SLIDER, minFrameRate, maxFrameRate, 1.0f);

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -127,12 +127,12 @@ protected:
 
 	void updateUserMenu(void);
 
-	RenderControls(FPSciApp* app, SessionConfig& config, bool& drawFps, bool& turbo, const int numReticles, float& brightness,
+	RenderControls(FPSciApp* app, SessionConfig& config, bool& drawFps, const int numReticles, float& brightness,
 		const shared_ptr<GuiTheme>& theme, const int maxFrameDelay = 360, const float minFrameRate = 1.0f, const float maxFrameRate=1000.0f, float width=400.0f, float height=10.0f);
 public:
-	static shared_ptr<RenderControls> create(FPSciApp* app, SessionConfig& config, bool& drawFps, bool& turbo, const int numReticles, float& brightness,
+	static shared_ptr<RenderControls> create(FPSciApp* app, SessionConfig& config, bool& drawFps, const int numReticles, float& brightness,
 		const shared_ptr<GuiTheme>& theme, const int maxFrameDelay = 360, const float minFrameRate = 1.0f, const float maxFrameRate=1000.0f, float width = 400.0f, float height = 10.0f) {
-		return createShared<RenderControls>(app, config, drawFps, turbo, numReticles, brightness, theme, maxFrameDelay, minFrameRate, maxFrameRate, width, height);
+		return createShared<RenderControls>(app, config, drawFps, numReticles, brightness, theme, maxFrameDelay, minFrameRate, maxFrameRate, width, height);
 	}
 };
 


### PR DESCRIPTION
This branch removes `emergencyTurbo` which was causing issues with controlling AA, bloom, and AO (from the scene) when not set.