### PR TITLE
Improve Question Specification

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -297,7 +297,7 @@ Questions are configured on a per experiment/session basis using the `questions`
 
 | Parameter Name        | Units  | Description                                                                      |
 |-----------------------|--------|----------------------------------------------------------------------------------|
-|`type`                 |`String`| The question type (required), can be `"MultipleChoice"`, `Rating`, or (text) `"Entry"`      |
+|`type`                 |`String`| The question type (required), can be `"MultipleChoice"`, `Rating`, `DropDown` or (text) `"Entry"`      |
 |`prompt`               |`String`| The question prompt (required), a string to present the user with                |
 |`title`                |`String`| The title for the feedback prompt                                                |
 |`options`              |`Array<String>`| An array of `String` options for `MultipleChoice` questions only          |
@@ -329,7 +329,7 @@ The user can specify one or more questions using the `questions` array, as demon
 ]
 ```
 
-Each question in the array is then asked of the user (via an independent time-sequenced dialog box) before being recorded to the output log. Note that `MultipleChoise` and `Rating` questions include a confirmation button that must be pressed to confirm the selection before proceeding.
+Each question in the array is then asked of the user (via an independent time-sequenced dialog box) before being recorded to the output log. Note that `MultipleChoice` and `Rating` questions include a confirmation button that must be pressed to confirm the selection before proceeding. `DropDown` questions use the same approach with a drop-down menu instead of button-based selection, note `DropDown` questions can be fullscreen but currently still require use of the cursor (`optionsKeys` are ignored).
 
 There are 2 primary differences between questions with `type` of `MultipleChoice` and `Rating`. These are:
 

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -305,6 +305,7 @@ Questions are configured on a per experiment/session basis using the `questions`
 |`fullscreen`           |`bool`  | When set this opens the dialog in "fullscreen" mode, overlaying all of the rendered content (default is `false`) |
 |`showCursor`           |`bool`  | Allows the experiment designer to hide the cursor while responding to this dialog (default is `true`). Best used with `optionKeys` set otherwise there may be no way to answer the question. Not intended for use with `"Entry"` question types. |
 |`randomOrder`          |`bool`  | Randomize the option order for `MultipleChoice` and `Rating` questions optionally    |
+|`optionsPerRow`        |`int`   | The number of options to display per row (for `MultipleChoice` questions only)   |
 
 The user can specify one or more questions using the `questions` array, as demonstrated below.
 
@@ -322,12 +323,18 @@ The user can specify one or more questions using the `questions` array, as demon
         "optionKeys" : ["A", "B", "C"],
         "fullscreen": true,
         "showCursor" : false,
-        "randomOrder": false
+        "randomOrder": true,
+        "optionsPerRow": 3
     }
 ]
 ```
 
 Each question in the array is then asked of the user (via an independent time-sequenced dialog box) before being recorded to the output log. Note that `MultipleChoise` and `Rating` questions include a confirmation button that must be pressed to confirm the selection before proceeding.
+
+There are 2 primary differences between questions with `type` of `MultipleChoice` and `Rating`. These are:
+
+1. `MultipleChoice` questions can specify an `optionsPerRow` field to control layout (otherwise defaults to 3). `Rating` questions always use a single row of responses (`optionsPerRow` = total # of options)
+2. `MultipleChoice` questions default to `randomOrder` = `true` (randomize option order) whereas `Rating` questions default to the provided option ordering
 
 ## HUD settings
 | Parameter Name        |Units      | Description                                                                                                           |

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -306,6 +306,10 @@ Questions are configured on a per experiment/session basis using the `questions`
 |`showCursor`           |`bool`  | Allows the experiment designer to hide the cursor while responding to this dialog (default is `true`). Best used with `optionKeys` set otherwise there may be no way to answer the question. Not intended for use with `"Entry"` question types. |
 |`randomOrder`          |`bool`  | Randomize the option order for `MultipleChoice` and `Rating` questions optionally    |
 |`optionsPerRow`        |`int`   | The number of options to display per row (for `MultipleChoice` questions only)   |
+|`fontSize`             |`float` | Set the base font size for all elements in the question                          |
+|`promptFontSize`       |`float` | The font size for the prompt text (overrides `fontSize`)                         |
+|`optionFontSize`       |`float` | The font size for the presented options (overrides `fontSize`), does not impact `DropDown` or `Entry` questions |
+|`buttonFontSize`       |`float` | The font size for the question clear/submit buttons if present (overrides `fontSize`)     |
 
 The user can specify one or more questions using the `questions` array, as demonstrated below.
 
@@ -314,7 +318,8 @@ The user can specify one or more questions using the `questions` array, as demon
     {
         "type": "Entry",
         "prompt": "Write some text!",
-        "title": "Example text entry"
+        "title": "Example text entry",
+        "fontSize": -1                  // This is the default value for all font sizes (corresponds to 12pt font)
     },
     {
         "type": "MultipleChoice",
@@ -324,7 +329,11 @@ The user can specify one or more questions using the `questions` array, as demon
         "fullscreen": true,
         "showCursor" : false,
         "randomOrder": true,
-        "optionsPerRow": 3
+        "optionsPerRow": 3,
+
+        "promptFontSize" = 12,          // Default for all fonts
+        "optionFontSize" = 20,          // Demonstration of using different size
+        "buttonFontSize" = 16
     }
 ]
 ```

--- a/source/Dialogs.h
+++ b/source/Dialogs.h
@@ -5,7 +5,7 @@
 class DialogBase : public GuiWindow {
 protected:
 	String m_prompt;
-	DialogBase(const shared_ptr<GuiTheme> theme, String title = "Dialog", Point2 pos = Point2(200.f, 200.0f), Point2 size = Point2(400.0f, 200.0f)) :
+	DialogBase(const shared_ptr<GuiTheme> theme, const String& title = "Dialog", Point2 pos = Point2(200.f, 200.0f), Point2 size = Point2(400.0f, 200.0f)) :
 		GuiWindow(title, theme, Rect2D::xywh(pos, size), GuiTheme::MENU_WINDOW_STYLE, GuiWindow::HIDE_ON_CLOSE) {};
 public:
 	String result = "";
@@ -56,8 +56,8 @@ protected:
 		}
 	}
 
-	SelectionDialog(String prompt, Array<String> options, const shared_ptr<GuiTheme>& theme,
-		String title = "Selection", bool submitButton = false, int itemsPerRow = 3,
+	SelectionDialog(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme>& theme,
+		const String& title = "Selection", bool submitButton = false, int itemsPerRow = 3,
 		Point2 size = Point2(400.0f, 400.0f), bool resize = true, Point2 pos = Point2(200.0f, 200.0f),	GFont::XAlign promptAlign = GFont::XALIGN_CENTER) :
 		DialogBase(theme, title, pos, size)
 	{
@@ -76,7 +76,7 @@ protected:
 		int cnt = 0;
 		int i = 0;
 		const int rows = options.length() / itemsPerRow;
-		for (String option : options) {
+		for (const String& option : options) {
 			cnt %= itemsPerRow;
 			if (cnt == 0) {
 				pane->beginRow();
@@ -121,8 +121,8 @@ protected:
 	};
 
 public:
-	static shared_ptr<SelectionDialog> create(String prompt, Array<String> options, const shared_ptr<GuiTheme> theme,
-		String title = "Selection", bool submitBtn = false, int itemsPerRow = 3, Point2 size = Point2(400.0f, 200.0f), bool resize = true, Point2 position = Point2(200.0f, 200.0f))
+	static shared_ptr<SelectionDialog> create(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme,
+		const String& title = "Selection", bool submitBtn = false, int itemsPerRow = 3, Point2 size = Point2(400.0f, 200.0f), bool resize = true, Point2 position = Point2(200.0f, 200.0f))
 	{
 		return createShared<SelectionDialog>(prompt, options, theme, title, submitBtn, itemsPerRow,  size, resize, position);
 	}
@@ -130,20 +130,20 @@ public:
 
 class YesNoDialog : public SelectionDialog {
 protected:
-	YesNoDialog(String question, const shared_ptr<GuiTheme> theme, String title = "Dialog", bool submitBtn=false) :
+	YesNoDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) :
 		SelectionDialog(question, Array<String>{"Yes", "No"}, theme, title, submitBtn) {};
 public:
-	static shared_ptr<YesNoDialog> create(String question, const shared_ptr<GuiTheme> theme, String title="Dialog", bool submitBtn=false){ 
+	static shared_ptr<YesNoDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title="Dialog", bool submitBtn=false){ 
 		return createShared<YesNoDialog>(question, theme, title, submitBtn);
 	}
 };
 
 class YesNoCancelDialog : public SelectionDialog {
 protected:
-	YesNoCancelDialog(String question, const shared_ptr<GuiTheme> theme, String title = "Dialog", bool submitBtn=false) :
+	YesNoCancelDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) :
 		SelectionDialog(question, Array<String>{"Yes", "No", "Cancel"}, theme, title, submitBtn) {};
 public:
-	static shared_ptr<YesNoCancelDialog> create(String question, const shared_ptr<GuiTheme> theme, String title = "Dialog", bool submitBtn=false) {
+	static shared_ptr<YesNoCancelDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) {
 		return createShared<YesNoCancelDialog>(question, theme, title, submitBtn);
 	}
 };
@@ -165,7 +165,7 @@ protected:
 		}
 	}
 
-	TextEntryDialog(String prompt, const shared_ptr<GuiTheme> theme, String title = "Dialog", bool allowEmpty = true,
+	TextEntryDialog(const String& prompt, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool allowEmpty = true,
 		Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f)) :
 		DialogBase(theme, title, position, size) 
 	{
@@ -196,8 +196,8 @@ protected:
 		if (resize) { pack(); }
 	}
 public:
-	static shared_ptr<TextEntryDialog> create(String prompt, const shared_ptr<GuiTheme> theme, 
-		String title = "Dialog", bool allowEmpty=true, Point2 size = Point2(400.0f, 300.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
+	static shared_ptr<TextEntryDialog> create(const String& prompt, const shared_ptr<GuiTheme> theme, 
+		const String& title = "Dialog", bool allowEmpty=true, Point2 size = Point2(400.0f, 300.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
 	{
 		return createShared<TextEntryDialog>(prompt, theme, title, allowEmpty, size, resize, position);
 	}
@@ -205,13 +205,54 @@ public:
 
 class RatingDialog : public SelectionDialog {
 protected:
-	RatingDialog(String prompt, Array<String> levels, const shared_ptr<GuiTheme> theme,
-		String title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f)) :
+	RatingDialog(const String& prompt, const Array<String>& levels, const shared_ptr<GuiTheme> theme,
+		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f)) :
 		SelectionDialog(prompt, levels, theme, title, submitBtn, levels.size(), size, resize, position, GFont::XALIGN_LEFT) {}
 public:
-	static shared_ptr<RatingDialog> create(String prompt, Array<String> levels, const shared_ptr<GuiTheme> theme,
-		String title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
+	static shared_ptr<RatingDialog> create(const String& prompt, const Array<String>& levels, const shared_ptr<GuiTheme> theme,
+		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
 	{
 		return createShared<RatingDialog>(prompt, levels, theme, title, submitBtn, size, resize, position);
 	}
+};
+
+class DropDownDialog : public DialogBase {
+protected:
+	int m_selIdx = 0;				// Default to first index
+	GuiDropDownList* m_dropDown;	// Drop down selection list
+	
+	void submitCallback() {
+		complete = true;
+		setVisible(false);
+	}
+
+	DropDownDialog(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", 
+		Point2 size = Point2(400.f, 200.f), bool resize=true, Point2 position = Point2(200.f, 200.f)) : DialogBase(theme, title, position, size) 
+	{
+		m_prompt = prompt;
+		GuiPane* pane = GuiWindow::pane();
+
+		pane->beginRow(); {
+			auto l = pane->addLabel(m_prompt);
+			l->setSize(0.99f * size[0], 50.0f);
+		} pane->endRow();
+		pane->beginRow(); {
+			m_dropDown = pane->addDropDownList("", options, &m_selIdx);
+			m_dropDown->setSize(0.99f * size[0], size[1] - 150.0f);
+		} pane->endRow();
+		pane->beginRow(); {
+			auto b = pane->addButton("Submit", std::bind(&DropDownDialog::submitCallback, this));
+			b->setSize(0.99f * size[0], 50.0f);
+		} pane->endRow();
+
+		if (resize) pack();
+
+	}
+public:
+	static shared_ptr<DropDownDialog> create(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme, const String& title = "Dialog",
+		Point2 size = Point2(400.f, 200.f), bool resize = true, Point2 position = Point2(200.f, 200.f))
+	{
+		return createShared<DropDownDialog>(prompt, options, theme, title, size, resize, position);
+	}
+
 };

--- a/source/Dialogs.h
+++ b/source/Dialogs.h
@@ -4,7 +4,7 @@
 // Internal class for ease of use
 class DialogBase : public GuiWindow {
 protected:
-	String m_prompt;
+	GuiText m_prompt;
 	DialogBase(const shared_ptr<GuiTheme> theme, const String& title = "Dialog", Point2 pos = Point2(200.f, 200.0f), Point2 size = Point2(400.0f, 200.0f)) :
 		GuiWindow(title, theme, Rect2D::xywh(pos, size), GuiTheme::MENU_WINDOW_STYLE, GuiWindow::HIDE_ON_CLOSE) {};
 public:
@@ -58,10 +58,12 @@ protected:
 
 	SelectionDialog(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme>& theme,
 		const String& title = "Selection", bool submitButton = false, int itemsPerRow = 3,
-		Point2 size = Point2(400.0f, 400.0f), bool resize = true, Point2 pos = Point2(200.0f, 200.0f),	GFont::XAlign promptAlign = GFont::XALIGN_CENTER) :
+		Point2 size = Point2(400.0f, 400.0f), bool resize = true, 
+		float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f,
+		Point2 pos = Point2(200.0f, 200.0f), GFont::XAlign promptAlign = GFont::XALIGN_CENTER) :
 		DialogBase(theme, title, pos, size)
 	{
-		m_prompt = prompt;
+		m_prompt = GuiText(prompt, shared_ptr<GFont>(), promptFontSize);
 		m_options = options;
 		GuiPane *pane = GuiWindow::pane();
 		pane->beginRow(); {
@@ -82,7 +84,7 @@ protected:
 				pane->beginRow();
 			}
 			m_callbacks.append(std::bind(&SelectionDialog::callback, this, option));
-			GuiButton* btn = pane->addButton(option, m_callbacks[i]);
+			GuiButton* btn = pane->addButton(GuiText(option, shared_ptr<GFont>(), optionFontSize), m_callbacks[i]);
 			if (!resize) {		// Larger buttons when not resizing
 				btn->setWidth(0.99f*size.x / itemsPerRow);
 				btn->setHeight(min(100.0f, 0.99f * size.y/rows));
@@ -103,8 +105,8 @@ protected:
 		if (submitButton) {
 			pane->beginRow(); {
 				// Create submit and clear buttons
-				m_clearBtn = pane->addButton("Clear", std::bind(&SelectionDialog::clearCallback, this));
-				m_submitBtn = pane->addButton("Submit", std::bind(&SelectionDialog::submitCallback, this));
+				m_clearBtn = pane->addButton(GuiText("Clear", shared_ptr<GFont>(), buttonFontSize), std::bind(&SelectionDialog::clearCallback, this));
+				m_submitBtn = pane->addButton(GuiText("Submit", shared_ptr<GFont>(), buttonFontSize) , std::bind(&SelectionDialog::submitCallback, this));
 				// Start with submit/clear buttons disabled
 				m_clearBtn->setEnabled(false);
 				m_submitBtn->setEnabled(false);		
@@ -122,29 +124,30 @@ protected:
 
 public:
 	static shared_ptr<SelectionDialog> create(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme,
-		const String& title = "Selection", bool submitBtn = false, int itemsPerRow = 3, Point2 size = Point2(400.0f, 200.0f), bool resize = true, Point2 position = Point2(200.0f, 200.0f))
+		const String& title = "Selection", bool submitBtn = false, int itemsPerRow = 3, Point2 size = Point2(400.0f, 200.0f), bool resize = true,
+		float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.0f, 200.0f))
 	{
-		return createShared<SelectionDialog>(prompt, options, theme, title, submitBtn, itemsPerRow,  size, resize, position);
+		return createShared<SelectionDialog>(prompt, options, theme, title, submitBtn, itemsPerRow, size, resize, promptFontSize, optionFontSize, buttonFontSize, position);
 	}
 };
 
 class YesNoDialog : public SelectionDialog {
 protected:
-	YesNoDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) :
-		SelectionDialog(question, Array<String>{"Yes", "No"}, theme, title, submitBtn) {};
+	YesNoDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false, float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f) :
+		SelectionDialog(question, Array<String>{"Yes", "No"}, theme, title, submitBtn, 2, G3D::Point2(400.f,400.f), true, promptFontSize, optionFontSize, buttonFontSize) {};
 public:
-	static shared_ptr<YesNoDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title="Dialog", bool submitBtn=false){ 
-		return createShared<YesNoDialog>(question, theme, title, submitBtn);
+	static shared_ptr<YesNoDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title="Dialog", bool submitBtn=false, float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f){
+		return createShared<YesNoDialog>(question, theme, title, submitBtn, promptFontSize, optionFontSize, buttonFontSize);
 	}
 };
 
 class YesNoCancelDialog : public SelectionDialog {
 protected:
-	YesNoCancelDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) :
-		SelectionDialog(question, Array<String>{"Yes", "No", "Cancel"}, theme, title, submitBtn) {};
+	YesNoCancelDialog(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false, float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f) :
+		SelectionDialog(question, Array<String>{"Yes", "No", "Cancel"}, theme, title, submitBtn, 3, G3D::Point2(400.f, 400.f), true, promptFontSize, optionFontSize, buttonFontSize) {};
 public:
-	static shared_ptr<YesNoCancelDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false) {
-		return createShared<YesNoCancelDialog>(question, theme, title, submitBtn);
+	static shared_ptr<YesNoCancelDialog> create(const String& question, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool submitBtn=false, float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f) {
+		return createShared<YesNoCancelDialog>(question, theme, title, submitBtn, promptFontSize, optionFontSize, buttonFontSize);
 	}
 };
 
@@ -166,10 +169,12 @@ protected:
 	}
 
 	TextEntryDialog(const String& prompt, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", bool allowEmpty = true,
-		Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f)) :
+		Point2 size = Point2(400.0f, 200.0f), bool resize=true, 
+		float promptFontSize = -1.f, float buttonFontSize = -1.f,
+		Point2 position = Point2(200.0f, 200.0f)) :
 		DialogBase(theme, title, position, size) 
 	{
-		m_prompt = prompt;
+		m_prompt = GuiText(prompt, shared_ptr<GFont>(), promptFontSize);
 		m_allowEmpty = allowEmpty;
 		GuiPane *pane = GuiWindow::pane();
 		pane->beginRow(); {
@@ -189,7 +194,7 @@ protected:
 		} pane->endRow();
 
 		pane->beginRow(); {
-			auto b = pane->addButton("Submit", std::bind(&TextEntryDialog::submitCallback, this));
+			auto b = pane->addButton(GuiText("Submit", shared_ptr<GFont>(), buttonFontSize), std::bind(&TextEntryDialog::submitCallback, this));
 			b->setSize(0.99f*size[0], 50.0f);
 		}
 
@@ -197,22 +202,25 @@ protected:
 	}
 public:
 	static shared_ptr<TextEntryDialog> create(const String& prompt, const shared_ptr<GuiTheme> theme, 
-		const String& title = "Dialog", bool allowEmpty=true, Point2 size = Point2(400.0f, 300.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
+		const String& title = "Dialog", bool allowEmpty=true, Point2 size = Point2(400.0f, 300.0f), bool resize=true,
+		float promptFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.0f, 200.0f))
 	{
-		return createShared<TextEntryDialog>(prompt, theme, title, allowEmpty, size, resize, position);
+		return createShared<TextEntryDialog>(prompt, theme, title, allowEmpty, size, resize, promptFontSize, buttonFontSize, position);
 	}
 };
 
 class RatingDialog : public SelectionDialog {
 protected:
 	RatingDialog(const String& prompt, const Array<String>& levels, const shared_ptr<GuiTheme> theme,
-		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f)) :
-		SelectionDialog(prompt, levels, theme, title, submitBtn, levels.size(), size, resize, position, GFont::XALIGN_LEFT) {}
+		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true,
+		float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.0f, 200.0f)) :
+		SelectionDialog(prompt, levels, theme, title, submitBtn, levels.size(), size, resize, promptFontSize, optionFontSize, buttonFontSize, position, GFont::XALIGN_LEFT) {}
 public:
 	static shared_ptr<RatingDialog> create(const String& prompt, const Array<String>& levels, const shared_ptr<GuiTheme> theme,
-		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true, Point2 position = Point2(200.0f, 200.0f))
+		const String& title = "Dialog", bool submitBtn=false, Point2 size = Point2(400.0f, 200.0f), bool resize=true,
+		float promptFontSize = -1.f, float optionFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.0f, 200.0f))
 	{
-		return createShared<RatingDialog>(prompt, levels, theme, title, submitBtn, size, resize, position);
+		return createShared<RatingDialog>(prompt, levels, theme, title, submitBtn, size, resize, promptFontSize, optionFontSize, buttonFontSize, position);
 	}
 };
 
@@ -227,9 +235,11 @@ protected:
 	}
 
 	DropDownDialog(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme, const String& title = "Dialog", 
-		Point2 size = Point2(400.f, 200.f), bool resize=true, Point2 position = Point2(200.f, 200.f)) : DialogBase(theme, title, position, size) 
+		Point2 size = Point2(400.f, 200.f), bool resize=true, 
+		float promptFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.f, 200.f)) : 
+		DialogBase(theme, title, position, size)
 	{
-		m_prompt = prompt;
+		m_prompt = GuiText(prompt, shared_ptr<GFont>(), promptFontSize);
 		GuiPane* pane = GuiWindow::pane();
 
 		pane->beginRow(); {
@@ -241,7 +251,7 @@ protected:
 			m_dropDown->setSize(0.99f * size[0], size[1] - 150.0f);
 		} pane->endRow();
 		pane->beginRow(); {
-			auto b = pane->addButton("Submit", std::bind(&DropDownDialog::submitCallback, this));
+			auto b = pane->addButton(GuiText("Submit", shared_ptr<GFont>(), buttonFontSize), std::bind(&DropDownDialog::submitCallback, this));
 			b->setSize(0.99f * size[0], 50.0f);
 		} pane->endRow();
 
@@ -250,9 +260,9 @@ protected:
 	}
 public:
 	static shared_ptr<DropDownDialog> create(const String& prompt, const Array<String>& options, const shared_ptr<GuiTheme> theme, const String& title = "Dialog",
-		Point2 size = Point2(400.f, 200.f), bool resize = true, Point2 position = Point2(200.f, 200.f))
+		Point2 size = Point2(400.f, 200.f), bool resize = true, float promptFontSize = -1.f, float buttonFontSize = -1.f, Point2 position = Point2(200.f, 200.f))
 	{
-		return createShared<DropDownDialog>(prompt, options, theme, title, size, resize, position);
+		return createShared<DropDownDialog>(prompt, options, theme, title, size, resize, promptFontSize, buttonFontSize, position);
 	}
 
 };

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -440,19 +440,21 @@ void FPSciApp::presentQuestion(Question question) {
 		if (question.optionKeys.length() > 0) {		// Add key-bound option to the dialog
 			for (int i = 0; i < options.length(); i++) { options[i] += format(" (%s)", question.optionKeys[i].toString()); }
 		}
-		dialog = SelectionDialog::create(question.prompt, options, theme, question.title, question.showCursor, question.optionsPerRow, size, !question.fullscreen);
+		dialog = SelectionDialog::create(question.prompt, options, theme, question.title, question.showCursor, question.optionsPerRow, size, !question.fullscreen,
+			question.promptFontSize, question.optionFontSize, question.buttonFontSize);
 		break;
 	case Question::Type::Entry:
-		dialog = TextEntryDialog::create(question.prompt, theme, question.title, false, size, !question.fullscreen);
+		dialog = TextEntryDialog::create(question.prompt, theme, question.title, false, size, !question.fullscreen, question.promptFontSize, question.buttonFontSize);
 		break;
 	case Question::Type::Rating:
 		if (question.optionKeys.length() > 0) {		// Add key-bound option to the dialog
 			for (int i = 0; i < options.length(); i++) { options[i] += format(" (%s)", question.optionKeys[i].toString()); }
 		}
-		dialog = RatingDialog::create(question.prompt, options, theme, question.title, question.showCursor, size, !question.fullscreen);
+		dialog = RatingDialog::create(question.prompt, options, theme, question.title, question.showCursor, size, !question.fullscreen,
+			question.promptFontSize, question.optionFontSize, question.buttonFontSize);
 		break;
 	case Question::Type::DropDown:
-		dialog = DropDownDialog::create(question.prompt, options, theme, question.title, size, !question.fullscreen);
+		dialog = DropDownDialog::create(question.prompt, options, theme, question.title, size, !question.fullscreen, question.promptFontSize, question.buttonFontSize);
 		break;
 	default:
 		throw "Unknown question type!";

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -440,7 +440,7 @@ void FPSciApp::presentQuestion(Question question) {
 		if (question.optionKeys.length() > 0) {		// Add key-bound option to the dialog
 			for (int i = 0; i < options.length(); i++) { options[i] += format(" (%s)", question.optionKeys[i].toString()); }
 		}
-		dialog = SelectionDialog::create(question.prompt, options, theme, question.title, question.showCursor, 3, size, !question.fullscreen);
+		dialog = SelectionDialog::create(question.prompt, options, theme, question.title, question.showCursor, question.optionsPerRow, size, !question.fullscreen);
 		break;
 	case Question::Type::Entry:
 		dialog = TextEntryDialog::create(question.prompt, theme, question.title, false, size, !question.fullscreen);

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -451,6 +451,9 @@ void FPSciApp::presentQuestion(Question question) {
 		}
 		dialog = RatingDialog::create(question.prompt, options, theme, question.title, question.showCursor, size, !question.fullscreen);
 		break;
+	case Question::Type::DropDown:
+		dialog = DropDownDialog::create(question.prompt, options, theme, question.title, size, !question.fullscreen);
+		break;
 	default:
 		throw "Unknown question type!";
 		break;

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -630,7 +630,17 @@ Question::Question(const Any& any) {
 		reader.getIfPresent("title", title);
 		reader.getIfPresent("fullscreen", fullscreen);
 		reader.getIfPresent("showCursor", showCursor);
-		reader.getIfPresent("randomOrder", randomOrder);
+		if (!reader.getIfPresent("randomOrder", randomOrder)) {
+			if (type == Type::Rating) {
+				randomOrder = false;		// Default to non-random order for rating questions
+			}
+		}
+		if (reader.getIfPresent("optionsPerRow", optionsPerRow)) {
+			if (type == Type::Rating) {		
+				// Ratings will ignore the optionsPerRow (always uses 1 row)
+				logPrintf("WARNING: Specified \"optionsPerRow\" parameter is ignored when using a \"Rating\" type question. If you'd like to change the layout look into using a \"MultipleChoice\" question instead!");
+			}
+		}
 
 		// Handle (optional) key binds for options (if provided)
 		if (type == Type::Rating || type == Type::MultipleChoice) {

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -654,6 +654,18 @@ Question::Question(const Any& any) {
 				throw format("Length of \"optionKeys\" (%d) did not match \"options\" (%d) for question!", optionKeys.length(), options.length());
 			}
 		}
+
+		// Get font sizes for elements
+		float baseFontSize;
+		if (reader.getIfPresent("fontSize", baseFontSize)) {
+			promptFontSize = baseFontSize;
+			optionFontSize = baseFontSize;
+			buttonFontSize = baseFontSize;
+		}
+		reader.getIfPresent("promptFontSize", promptFontSize);
+		reader.getIfPresent("optionFontSize", optionFontSize);
+		reader.getIfPresent("buttonFontSize", buttonFontSize);
+
 		break;
 	default:
 		debugPrintf("Settings version '%d' not recognized in Question.\n", settingsVersion);

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -621,8 +621,12 @@ Question::Question(const Any& any) {
 			type = Type::Rating;
 			reader.get("options", options, "An \"options\" Array must be specified with \"Rating\" style questions!");
 		}
+		else if (!typeStr.compare("DropDown")) {
+			type = Type::DropDown;
+			reader.get("options", options, "An \"options\" Array must be specified with \"DropDown\" style questions!");
+		}
 		else {
-			throw format("Unrecognized question \"type\" String \"%s\". Valid options are \"MultipleChoice\" or \"Entry\"", typeStr);
+			throw format("Unrecognized question \"type\" String \"%s\". Valid options are \"MultipleChoice\", \"Rating\", \"DropDown\", or \"Entry\"", typeStr);
 		}
 
 		// Get the question prompt (required) and title (optional)
@@ -631,8 +635,8 @@ Question::Question(const Any& any) {
 		reader.getIfPresent("fullscreen", fullscreen);
 		reader.getIfPresent("showCursor", showCursor);
 		if (!reader.getIfPresent("randomOrder", randomOrder)) {
-			if (type == Type::Rating) {
-				randomOrder = false;		// Default to non-random order for rating questions
+			if (type == Type::MultipleChoice) {
+				randomOrder = true;		// Default to random order for multiple choice questions
 			}
 		}
 		if (reader.getIfPresent("optionsPerRow", optionsPerRow)) {

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -312,6 +312,9 @@ public:
 	bool showCursor = true;				///< Show cursor during question response window (allow clicking for selection)?
 	bool randomOrder = false;			///< Randomize question response order?
 	int optionsPerRow = 3;				///< Number of options per row (defaults to 3 for multiple choice, # of options for ratings)
+	float promptFontSize = -1.f;		///< Font size for prompt text
+	float optionFontSize = -1.f;		///< Font size for question entry/options
+	float buttonFontSize = -1.f;		///< Font size for submit/cancel buttons
 
 	Question() {};
 	Question(const Any& any);

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -310,6 +310,7 @@ public:
 	bool fullscreen = false;			///< Show this question as fullscreen?
 	bool showCursor = true;				///< Show cursor during question response window (allow clicking for selection)?
 	bool randomOrder = true;			///< Randomize question response order?
+	int optionsPerRow = 3;				///< Number of options per row (defaults to 3 for multiple choice, # of options for ratings)
 
 	Question() {};
 	Question(const Any& any);

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -298,7 +298,8 @@ public:
 		None,
 		MultipleChoice,
 		Entry,
-		Rating
+		Rating,
+		DropDown
 	};
 
 	Type type = Type::None;
@@ -309,7 +310,7 @@ public:
 	String result = "";					///< Reported result (not specified as configuration)
 	bool fullscreen = false;			///< Show this question as fullscreen?
 	bool showCursor = true;				///< Show cursor during question response window (allow clicking for selection)?
-	bool randomOrder = true;			///< Randomize question response order?
+	bool randomOrder = false;			///< Randomize question response order?
 	int optionsPerRow = 3;				///< Number of options per row (defaults to 3 for multiple choice, # of options for ratings)
 
 	Question() {};


### PR DESCRIPTION
This branch improves specification of questions to clarify some issues and improve control of presentation of questions. Changes include:

1. Automatically default `randomOrder` to false when displaying questions with `type` of `Rating`
2. Add a `optionsPerRow` field that defaults to `3` (maintains old behavior) but allows custom layout of questions with `type` of `MultipleChoice`
3. Warn the user (via log.txt) that when a question with `type` of `Rating` is provided the `optionsPerRow` will be ignored in favor of displaying all options on one row (use `MultipleChoice` questions for controlled layout).
4. Allows font size setting for questions.

Merging this PR closes #344