### PR TITLE
Destination target offset fix

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -331,7 +331,7 @@ void Session::spawnTrialTargets(Point3 initialSpawnPos, bool previewMode) {
 		// Check for case w/ destination array
 		shared_ptr<TargetEntity> t;
 		if (target->destinations.size() > 0) {
-			Point3 offset = isWorldSpace ? target->destinations[0].position : f.pointToWorldSpace(Point3(0, 0, -m_targetDistance));
+			Point3 offset = isWorldSpace ? Point3(0.f, 0.f, 0.f) : f.pointToWorldSpace(Point3(0, 0, -m_targetDistance));
 			t = spawnDestTarget(target, offset, previewColor, i, name);
 		}
 		// Otherwise check if this is a jumping target
@@ -799,7 +799,7 @@ void Session::endLogging() {
 
 shared_ptr<TargetEntity> Session::spawnDestTarget(
 	shared_ptr<TargetConfig> config,
-	const Point3& position,
+	const Point3& offset,
 	const Color3& color,
 	const int paramIdx,
 	const String& name)
@@ -809,12 +809,11 @@ shared_ptr<TargetEntity> Session::spawnDestTarget(
 	const String nameStr = name.empty() ? format("target%03d", ++m_lastUniqueID) : name;
 	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 
-	const shared_ptr<TargetEntity>& target = TargetEntity::create(config, nameStr, m_scene, (*m_targetModels)[config->id][scaleIndex], position, scaleIndex, paramIdx);
+	const shared_ptr<TargetEntity>& target = TargetEntity::create(config, nameStr, m_scene, (*m_targetModels)[config->id][scaleIndex], offset, scaleIndex, paramIdx);
 
 	// Update parameters for the target
 	target->setHitSound(config->hitSound, m_app->soundTable, config->hitSoundVol);
 	target->setDestoyedSound(config->destroyedSound, m_app->soundTable, config->destroyedSoundVol);
-	target->setFrame(position);
 	target->setColor(color);
 
 	// Add target to array and scene

--- a/source/Session.h
+++ b/source/Session.h
@@ -275,7 +275,7 @@ protected:
 
 	shared_ptr<TargetEntity> spawnDestTarget(
 		shared_ptr<TargetConfig> config,
-		const Point3& position,
+		const Point3& offset,
 		const Color3& color,
 		const int paramIdx,
 		const String& name = "");

--- a/source/TargetEntity.cpp
+++ b/source/TargetEntity.cpp
@@ -218,8 +218,10 @@ void TargetEntity::setDestinations(const Array<Destination> destinationArray) {
 
 void TargetEntity::onSimulation(SimTime absoluteTime, SimTime deltaTime) {
 	// Check whether we have any destinations yet...
-	if (m_destinations.size() < 2)
+	if (m_destinations.size() < 2) {
+		setFrame(m_destinations[0].position + m_offset);
 		return;
+	}
 
 	if (m_spawnTime == 0) m_spawnTime = absoluteTime;						// Get a spawn time (if we don't have one already)
 	SimTime time = fmod(absoluteTime-m_spawnTime, getPathTime());			// Compute a local time (modulus the path time)

--- a/source/WaypointManager.cpp
+++ b/source/WaypointManager.cpp
@@ -235,7 +235,7 @@ bool WaypointManager::loadWaypoints(String filename) {
 
 	if (t.destSpace == "player") {
 		CFrame f = m_app->playerCamera->frame();
-		Point3 offset = f.pointToWorldSpace(Point3(0, 0, -1.0f));
+		Point3 offset = f.pointToWorldSpace(Point3(0, 0, -1.0f));		// The -1 here matches the session m_targetDistance value
 		// Adjust player space target destinations for preview
 		for (Destination& d : m_waypoints) {
 			d.position += offset;	// Add current camera frame as offset

--- a/source/WaypointManager.cpp
+++ b/source/WaypointManager.cpp
@@ -232,6 +232,15 @@ bool WaypointManager::loadWaypoints(String filename) {
 	if (t.destinations.size() > 0) {
 		setWaypoints(t.destinations);
 	}
+
+	if (t.destSpace == "player") {
+		CFrame f = m_app->playerCamera->frame();
+		Point3 offset = f.pointToWorldSpace(Point3(0, 0, -1.0f));
+		// Adjust player space target destinations for preview
+		for (Destination& d : m_waypoints) {
+			d.position += offset;	// Add current camera frame as offset
+		}
+	}
 	return true;
 }
 


### PR DESCRIPTION
This branch cleans up a sloppy implementation of target offsets that was not thoroughly tested.

It corrects offset values to 0 for world-space targets (as expected) and leaves the existing offsets for player-space destination targets. It should also correct for player-space targets loaded via the waypoint manager at the current player position.

Merging this PR closes #352.