### PR TITLE
Random order question key bind fix

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -313,6 +313,8 @@ Questions are configured on a per experiment/session basis using the `questions`
 
 The user can specify one or more questions using the `questions` array, as demonstrated below.
 
+Note that when using `randomOrder` the options key bindings specified in `optionKeys` remains static (i.e. while ordering of presented options will change the keypress used to enter any given option will remain constant between the `options` and `optionKeys` array).
+
 ```
 "questions" : [
     {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -438,7 +438,14 @@ void FPSciApp::presentQuestion(Question question) {
 	switch (question.type) {
 	case Question::Type::MultipleChoice:
 		if (question.optionKeys.length() > 0) {		// Add key-bound option to the dialog
-			for (int i = 0; i < options.length(); i++) { options[i] += format(" (%s)", question.optionKeys[i].toString()); }
+			for (int i = 0; i < options.length(); i++) { 
+				// Find the correct index for this option (order might be randomized)
+				int keyIdx;
+				for (keyIdx = 0; keyIdx < question.options.length(); keyIdx++) {
+					if (options[i] == question.options[keyIdx]) break;
+				}
+				options[i] += format(" (%s)", question.optionKeys[keyIdx].toString()); 
+			}
 		}
 		dialog = SelectionDialog::create(question.prompt, options, theme, question.title, question.showCursor, question.optionsPerRow, size, !question.fullscreen,
 			question.promptFontSize, question.optionFontSize, question.buttonFontSize);


### PR DESCRIPTION
This branch fixes a bug when using `randomOrder` questions with `optionKeys` specified. Previously logged responses were potentially incorrect in this configuration. Now the mapping of `options` to `optionKeys` does not change when `randomOrder = true` is specified in config. Only the presented order of options is changed (the key binds remain the same).

Merging this PR closes #356.