### PR TITLE
Add specification of target glossiness to configuration

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -81,7 +81,8 @@ The following configuration is universal to all target types.
 * `id` a short string to refer to this target information
 * `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified. A value of `-1` creates a target that respawns infinitely (trial ends when ammo or task time runs out).
 * `visualSize` is a vector indicating the minimum ([0]) and maximum ([1]) visual size for the target (in deg)
-* `colors` is an array of 2 colors (max and min health) which are interpolated between based on target damage (note this setting override the experiment or session-level [`targetHealthColors`](general_config.md#target-rendering) setting). If unspecified the experiment/session level settings are used.
+* `colors` is an array of 2 colors (max and min health) which are interpolated between based on target damage (note this setting overrides the experiment or session-level [`targetHealthColors`](general_config.md#target-rendering) setting). If unspecified the experiment/session level settings are used.
+* `gloss` is a `Color4` representing glossyness, the first 3 channels are RGB w/ alpha representing minimum reflection (F0). Set all channels to 0 or do not specify to disable glossy reflections (note this setting overrides the experiment or session-level [`targetGloss`](general_config.md#target-rendering) setting). If unspecified the experiment/session level settings are used.
 * `destSpace` the space for which the target is rendered (useful for non-destiantion based targets, "player" or "world")
 * `hitSound` is a filename for the sound to play when the target is hit but not destroyed (for no sound use an empty string).
 * `hitSoundVol` provides the volume (as a float) for the hit sound to be played at (default is `1.0`).

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -491,6 +491,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 | Parameter Name        |Units                  | Description                                                                        |
 |-----------------------|-----------------------|------------------------------------------------------------------------------------|
 |`targetHealthColors`   |[`Color3`, `Color3`]   | The max/min health colors for the target as an array of [`max color`, `min color`], if you do not want the target to change color as its health drops, set these values both to the same color                                              |
+|`targetGloss`          |`Color4`               | The target glossy (reflection) value, first 3 channels are RGB w/ alpha representing minimum reflection (F0). Set all channels to 0 or do not specify to disable glossy reflections       |
 |`showReferenceTarget`   |`bool`                | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -491,7 +491,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 | Parameter Name        |Units                  | Description                                                                        |
 |-----------------------|-----------------------|------------------------------------------------------------------------------------|
 |`targetHealthColors`   |[`Color3`, `Color3`]   | The max/min health colors for the target as an array of [`max color`, `min color`], if you do not want the target to change color as its health drops, set these values both to the same color                                              |
-|`targetGloss`          |`Color4`               | The target glossy (reflection) value, first 3 channels are RGB w/ alpha representing minimum reflection (F0). Set all channels to 0 or do not specify to disable glossy reflections       |
+|`targetGloss`          |`Color4`               | The target glossy (reflection) value, first 3 channels are RGB w/ alpha representing minimum reflection (F0). Set all channels to 0 or do not specify to disable glossy reflections. This sets the glossy color for the reference target in addition to trial targets       |
 |`showReferenceTarget`   |`bool`                | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
@@ -525,6 +525,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 "showPreviewTargetsWithReference" : false,      // Don't show the preview targets with the reference
 "showReferenceTargetMissDecals" : true,         // Show miss decals for reference targets
 "previewTargetColor" = Color3(0.5, 0.5, 0.5),   // Use gray for preview targets (if they are shown)
+"targetGloss" = Color4(0.4f, 0.2f, 0.1f, 0.8f), // Use the target gloss behavior from FPSci v22.02.01 and earlier
 ```
 
 ### Target Health Bars

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -280,10 +280,18 @@ Array<shared_ptr<UniversalMaterial>> FPSciApp::makeMaterials(shared_ptr<TargetCo
 		else {
 			color = lerpColor(experimentConfig.targetView.healthColors, complete);
 		}
+		Color4 gloss;
+		if (notNull(tconfig) && tconfig->hasGloss) {
+			gloss = tconfig->gloss;
+		}
+		else {
+			gloss = experimentConfig.targetView.gloss;
+		}
+
 		UniversalMaterial::Specification materialSpecification;
 		materialSpecification.setLambertian(Texture::Specification(color));
 		materialSpecification.setEmissive(Texture::Specification(color * 0.7f));
-		materialSpecification.setGlossy(Texture::Specification(Color4(0.4f, 0.2f, 0.1f, 0.8f)));
+		materialSpecification.setGlossy(Texture::Specification(gloss));					// Used to be Color4(0.4f, 0.2f, 0.1f, 0.8f)
 		targetMaterials.append(UniversalMaterial::create(materialSpecification));
 	}
 	return targetMaterials;

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -439,6 +439,7 @@ void TargetViewConfig::load(FPSciAnyTableReader reader, int settingsVersion) {
 		if (gotColors && healthColors.length() < 1) {
 			throw "Specified \"healthColors\" doesn't contain at least one Color3!";
 		}
+		reader.getIfPresent("targetGloss", gloss);
 		reader.getIfPresent("targetHealthBarColors", healthBarColors);
 		reader.getIfPresent("showFloatingCombatText", showCombatText);
 		reader.getIfPresent("floatingCombatTextSize", combatTextSize);

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -196,6 +196,8 @@ public:
 		Color3(1.0, 0.0, 0.0)
 	};
 
+	Color4 gloss;		///< Target glossyness (alpha is F0 or minimum reflectivity, see G3D docs)
+
 	// Target health bars
 	bool            showHealthBars = false;									///< Display a target health bar?
 	Point2          healthBarSize = Point2(100.0f, 10.0f);					///< Health bar size (in pixels)

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -815,7 +815,9 @@ shared_ptr<TargetEntity> Session::spawnDestTarget(
 	target->setHitSound(config->hitSound, m_app->soundTable, config->hitSoundVol);
 	target->setDestoyedSound(config->destroyedSound, m_app->soundTable, config->destroyedSoundVol);
 	target->setFrame(position);
-	target->setColor(color);
+
+	Color4 gloss = config->hasGloss ? config->gloss : m_app->experimentConfig.targetView.gloss;
+	target->setColor(color, gloss);
 
 	// Add target to array and scene
 	insertTarget(target);
@@ -840,7 +842,7 @@ shared_ptr<FlyingEntity> Session::spawnReferenceTarget(
 
 	// Setup additional target parameters
 	target->setFrame(position);
-	target->setColor(color);
+	target->setColor(color, m_app->experimentConfig.targetView.gloss);
 
 	// Add target to array and scene
 	insertTarget(target);
@@ -869,7 +871,9 @@ shared_ptr<FlyingEntity> Session::spawnFlyingTarget(
 	}
 	target->setHitSound(config->hitSound, m_app->soundTable,  config->hitSoundVol);
 	target->setDestoyedSound(config->destroyedSound, m_app->soundTable, config->destroyedSoundVol);
-	target->setColor(color);
+
+	Color4 gloss = config->hasGloss ? config->gloss : m_app->experimentConfig.targetView.gloss;
+	target->setColor(color, gloss);
 
 	// Add the target to the scene/target array
 	insertTarget(target);
@@ -899,7 +903,9 @@ shared_ptr<JumpingEntity> Session::spawnJumpingTarget(
 	}
 	target->setHitSound(config->hitSound, m_app->soundTable, config->hitSoundVol);
 	target->setDestoyedSound(config->destroyedSound, m_app->soundTable, config->destroyedSoundVol);
-	target->setColor(color);
+
+	Color4 gloss = config->hasGloss ? config->gloss : m_app->experimentConfig.targetView.gloss;
+	target->setColor(color, gloss);
 
 	// Add the target to the scene/target array
 	insertTarget(target);

--- a/source/TargetEntity.cpp
+++ b/source/TargetEntity.cpp
@@ -75,6 +75,7 @@ TargetConfig::TargetConfig(const Any& any) {
 		reader.getIfPresent("destroyedSound", destroyedSound);
 		reader.getIfPresent("destroyedSoundVol", destroyedSoundVol);
 		reader.getIfPresent("colors", colors);
+		hasGloss = reader.getIfPresent("gloss", gloss);
 
 		break;
 	default:

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -172,11 +172,11 @@ public:
 		destinationIdx = 0;
 	}
 
-	void setColor(const Color3& color, const Color4& glossy = Color4()) {
+	void setColor(const Color3& color, const Color4& gloss = Color4()) {
 		UniversalMaterial::Specification materialSpecification;
 		materialSpecification.setLambertian(Texture::Specification(color));
 		materialSpecification.setEmissive(Texture::Specification(color * 0.7f));
-		materialSpecification.setGlossy(Texture::Specification(glossy));						// Used to be Color4(0.4f, 0.2f, 0.1f, 0.8f)
+		materialSpecification.setGlossy(Texture::Specification(gloss));						// Used to be Color4(0.4f, 0.2f, 0.1f, 0.8f)
 
 		const shared_ptr<ArticulatedModel::Pose>& amPose = ArticulatedModel::Pose::create();
 		amPose->materialTable.set("core/icosahedron_default", UniversalMaterial::create(materialSpecification));

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -82,6 +82,8 @@ public:
 
 	// Target color based on health
 	Array<Color3>   colors;									///< Target start/end color (based on target health)
+	Color4			gloss;									///< Target gloss (alpha is F0, see docs)
+	bool			hasGloss = false;						///< Target has gloss specified
 
 	Any modelSpec = PARSE_ANY(ArticulatedModel::Specification{			///< Basic model spec for target
 		filename = "model/target/target.obj";
@@ -170,11 +172,11 @@ public:
 		destinationIdx = 0;
 	}
 
-	void setColor(const Color3& color) {
+	void setColor(const Color3& color, const Color4& glossy = Color4()) {
 		UniversalMaterial::Specification materialSpecification;
 		materialSpecification.setLambertian(Texture::Specification(color));
 		materialSpecification.setEmissive(Texture::Specification(color * 0.7f));
-		materialSpecification.setGlossy(Texture::Specification(Color4(0.4f, 0.2f, 0.1f, 0.8f)));
+		materialSpecification.setGlossy(Texture::Specification(glossy));						// Used to be Color4(0.4f, 0.2f, 0.1f, 0.8f)
 
 		const shared_ptr<ArticulatedModel::Pose>& amPose = ArticulatedModel::Pose::create();
 		amPose->materialTable.set("core/icosahedron_default", UniversalMaterial::create(materialSpecification));


### PR DESCRIPTION
This branch reverts a hard-coded glossiness assumption that was previously used in FPSci. Targets and session/experiment level config can now specify their `gloss` and `targetGloss` respectively with per-target gloss overriding the global settings (similar to target color configuration).