### PR TITLE
Remove duplicate save of user status

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -505,7 +505,6 @@ void Session::updatePresentationState()
         
 				// Save current user config and status
 				m_app->saveUserConfig(true);											
-				m_app->saveUserStatus();
         
 				closeSessionProcesses();					// Close the process we started at session start (if there is one)
 				runSessionCommands("end");					// Launch processes for the end of the session


### PR DESCRIPTION
This branch removes a 2nd save of user status from the session state machine.