### PR TITLE
Check for legal results filename

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -726,7 +726,8 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	const String logFileBasename = sessConfig->logger.logToSingleDb ? 
 		experimentConfig.description + "_" + userStatusTable.currentUser + "_" + m_expConfigHash :
 		id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
-	const String logFilename = FilePath::makeLegalFilename(logFileBasename + ".db");
+	const String logFilename = FilePath::makeLegalFilename(logFileBasename);
+	// This is the specified path and log basename with illegal characters replaced, but not suffix (.db)
 	const String logPath = resultsDirPath + logFilename;
 
 	if (systemConfig.hasLogger) {
@@ -745,7 +746,7 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	}
 
 	// Initialize the experiment (this creates the results file)
-	sess->onInit(logPath +".db", experimentConfig.description + "/" + sessConfig->description);
+	sess->onInit(logPath, experimentConfig.description + "/" + sessConfig->description);
 
 	// Don't create a results file for a user w/ no sessions left
 	if (m_userSettingsWindow->sessionsForSelectedUser() == 0) {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -617,7 +617,7 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	if (!id.empty() && ids.contains(id)) {
 		// Load the session config specified by the id
 		sessConfig = experimentConfig.getSessionConfigById(id);
-		logPrintf("User selected session: %s. Updating now...\n", id);
+		logPrintf("User selected session: %s. Updating now...\n", id.c_str());
 		m_userSettingsWindow->setSelectedSession(id);
 		// Create the session based on the loaded config
 		sess = Session::create(this, sessConfig);

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -723,14 +723,12 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	}
 
 	// Create and check log file name
-	const String logFilename = sessConfig->logger.logToSingleDb ? 
+	const String logFileBasename = sessConfig->logger.logToSingleDb ? 
 		experimentConfig.description + "_" + userStatusTable.currentUser + "_" + m_expConfigHash :
 		id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
-	if (!FilePath::isLegalFilename(logFilename + ".db")) {
-		throw "Results filename \"" + logFilename + ".db\" is not valid! Make sure experiment description and username do not include any illegal characters (e.g. '.', '\\', '/', '*')";
-	}
-
+	const String logFilename = FilePath::makeLegalFilename(logFileBasename + ".db");
 	const String logPath = resultsDirPath + logFilename;
+
 	if (systemConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -222,10 +222,10 @@ void Session::onInit(String filename, String description) {
 		if (m_config->logger.enable) {
 			UserConfig user = *m_app->currentUser();
 			// Setup the logger and create results file
-			logger = FPSciLogger::create(filename, user.id, m_config, description);
+			logger = FPSciLogger::create(filename + ".db", user.id, m_config, description);
 			logger->logTargetTypes(m_app->experimentConfig.getSessionTargets(m_config->id));			// Log target info at start of session
 			logger->logUserConfig(user, m_config->id, m_config->player.turnScale);						// Log user info at start of session
-			m_dbFilename = filename.substr(0, filename.length() - 3);
+			m_dbFilename = filename;
 		}
 
 		runSessionCommands("start");				// Run start of session commands


### PR DESCRIPTION
This branch adds a `FilePath::isLegalFilename()` check on the filename used for the results database. Previously the results could fail to write due to an illegal character in either an experiment description or a user name.

The new check should throw an exception when any invalid filename character is detected in the results filename. It is worth noting this may catch characters that technically legal but not encouraged for file naming.

Merging this PR closes #351 