### PR TITLE
Pre-play audio on first load

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -711,9 +711,13 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 	weapon->loadSounds();
 	if (!sessConfig->audio.sceneHitSound.empty()) {
 		m_sceneHitSound = Sound::create(System::findDataFile(sessConfig->audio.sceneHitSound));
+		// Play silently to pre-load the sound
+		m_sceneHitSound->play(0.f);
 	}
 	if (!sessConfig->audio.refTargetHitSound.empty()) {
 		m_refTargetHitSound = Sound::create(System::findDataFile(sessConfig->audio.refTargetHitSound));
+		// Play silently to pre-load the sound
+		m_refTargetHitSound->play(0.f);
 	}
 
 	// Load static HUD textures

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -196,6 +196,8 @@ public:
 			}
 			m_hitSound = soundTable[hitSoundFilename];
 			m_hitSoundVol = hitSoundVol;
+			// Play with volume 0 to pre-load
+			m_hitSound->play(0.f);
 		}
 	}
 
@@ -208,6 +210,8 @@ public:
 			}
 			m_destroyedSound = soundTable[destroyedSoundFilename];
 			m_destroyedSoundVol = destroyedSoundVol;
+			// Play with volume 0 to pre-load
+			m_destroyedSound->play(0.f);
 		}
 	}
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -220,9 +220,18 @@ public:
 
 	void loadSounds() {
 		// Check for play mode specific parameters
-		if (notNull(m_fireAudio)) { m_fireAudio->stop(); }
-		if(!m_config->fireSound.empty()) m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->loopAudio());
-		else { m_fireSound = nullptr; }
+		if (notNull(m_fireAudio)) { 
+			m_fireAudio->stop(); 
+		}
+		if (!m_config->fireSound.empty()) {
+			m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->loopAudio());
+			// Play the sound with 0 volume to load it
+			m_fireAudio = m_fireSound->play(0.f);
+			m_fireAudio->stop();
+		}
+		else { 
+			m_fireSound = nullptr; 
+		}
 	}
 	// Plays the sound based on the weapon fire mode
 	void playSound(bool shotFired, bool shootButtonUp);


### PR DESCRIPTION
This PR makes audio play when first loaded to avoid stuttering when it first needs to play.

When finished, closes #375 

With some luck may also help #275 , but it doesn't fix that yet.