### PR TITLE
Add `requireUserAdd` parameter

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -607,6 +607,7 @@ These flags control the display of the in-game user menu:
 |`showUserSettings`                 |`bool`     |Show the per-user customization (sensitivity, reticle, etc) options    |
 |`allowSessionChange`               |`bool`     |Allow users to change the session using a user menu dropdown           |
 |`allowUserAdd`                     |`bool`     |Allow users to add new users to the experiment                         |
+|`requireUserAdd`                   |`bool`     |Require subjects to always create a new user on each run of FPSci      |
 |`allowUserSettingsSave`            |`bool`     |Allow the user to save their settings from the menu                    |
 |`allowSensitivityChange`           |`bool`     |Allow the user to change their (cm/360) sensitivity value from the menu|
 |`allowTurnScaleChange`             |`bool`     |Allow the user to change their turn scale from the menu                |
@@ -627,6 +628,7 @@ These flags control the display of the in-game user menu:
 "showUserSettings": true,               // Show the user settings
 "allowSessionChange": true,             // Allow the user to change sessions using the menu dropdown
 "allowUserAdd": false,                  // Don't allow new user add by default
+"requireUserAdd": false,                // Don't require new users by default
 "allowUserSettingsSave": true,          // Allow the user to save their settings changes
 "allowSensitivityChange": true,         // Allow the user to change the cm/360 sensitivity
 "allowTurnScaleChange": true,           // Allow the user to change their turn scale (see below)

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -98,6 +98,7 @@ void FPSciApp::openUserSettingsWindow() {
 
 /** Handle the user settings window visibility */
 void FPSciApp::closeUserSettingsWindow() {
+	if (sessConfig->menu.requireUserAdd && !userAdded) return;		// Don't close if a user hasn't bee
 	if (sessConfig->menu.allowUserSettingsSave) {		// If the user could have saved their settings
 		saveUserConfig(true);							// Save the user config (if it has changed) whenever this window is closed
 	}
@@ -428,7 +429,8 @@ void FPSciApp::makeGUI() {
 
 	// Add the control panes here
 	updateControls();
-	m_showUserMenu = experimentConfig.menu.showMenuOnStartup;
+	// If we require a new user show the menu on startup regardless of configuration
+	m_showUserMenu = experimentConfig.menu.showMenuOnStartup || experimentConfig.menu.requireUserAdd;
 }
 
 void FPSciApp::exportScene() {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -98,19 +98,27 @@ void FPSciApp::openUserSettingsWindow() {
 
 /** Handle the user settings window visibility */
 void FPSciApp::closeUserSettingsWindow() {
-	if (sessConfig->menu.requireUserAdd && !userAdded) return;		// Don't close if a user hasn't bee
-	if (sessConfig->menu.allowUserSettingsSave) {		// If the user could have saved their settings
-		saveUserConfig(true);							// Save the user config (if it has changed) whenever this window is closed
+	// Don't allow window close until a user has been added
+	if (sessConfig->menu.requireUserAdd && !userAdded) {
+		return;
 	}
-	if (!dialog) {										// Don't allow the user menu to hide the mouse when a dialog box is open
-		setMouseInputMode(MouseInputMode::MOUSE_FPM);	// Set mouse mode to FPM to allow steering the view again
+	// If the user could have saved their settings, save on close
+	if (sessConfig->menu.allowUserSettingsSave) {
+		saveUserConfig(true);
+	}
+	// Don't allow the user menu to hide the mouse when a dialog box is open
+	if (!dialog) {
+		// Set mouse mode to FPM to allow steering the view again
+		setMouseInputMode(MouseInputMode::MOUSE_FPM);
 	}
 	m_userSettingsWindow->setVisible(false);
 }
 
 void FPSciApp::saveUserConfig(bool onDiff) {
 	// Check for save on diff, without mismatch
-	if (onDiff && m_lastSavedUser == *currentUser()) return;
+	if (onDiff && m_lastSavedUser == *currentUser()) {
+		return;
+	}
 	if (notNull(sess->logger)) {
 		sess->logger->logUserConfig(*currentUser(), sessConfig->id, sessConfig->player.turnScale);
 	}

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -217,6 +217,7 @@ public:
 
 	bool		frameToggle			= false;	///< Simple toggle flag used for frame rate click-to-photon monitoring
 	bool		updateUserMenu		= false;	///< Semaphore to indicate user settings needs update
+	bool		userAdded			= false;	///< Flag to track whether a new user has been added
 	bool		reinitExperiment	= false;	///< Semaphore to indicate experiment needs to be reinitialized
 
 	int			experimentIdx = 0;				///< Index of the current experiment

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -692,10 +692,10 @@ Array<String> UserMenu::updateSessionDropDown() {
 }
 
 void UserMenu::updateUserPress() {
-	if (m_lastUserIdx != m_ddCurrUserIdx) {
+	if (m_ddLastUserIdx != m_ddCurrUserIdx) {
 		String userId = m_userDropDown->get(m_ddCurrUserIdx);
 		updateUser(userId);
-		m_lastUserIdx = m_ddCurrUserIdx;
+		m_ddLastUserIdx = m_ddCurrUserIdx;
 	}
 }
 

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -174,7 +174,7 @@ protected:
 
 	int m_ddCurrUserIdx = 0;									///< Current user index
 	int m_ddCurrSessIdx = 0;									///< Current session index
-	int m_lastUserIdx = -1;										///< Previously selected user in the drop-down
+	int m_ddLastUserIdx = -1;									///< Previously selected user in the drop-down
 
 	String m_newUser;											///< New user string
 

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -17,6 +17,7 @@ public:
 	bool showUserSettings = true;								///< Show the user settings options (master switch)
 	bool allowSessionChange = true;								///< Allow the user to change the session with the menu drop-down
 	bool allowUserAdd = false;									///< Allow the user to add a new user to the experiment
+	bool requireUserAdd = false;								///< Require a new user to be created
 	bool allowUserSettingsSave = true;							///< Allow the user to save settings changes
 	bool allowSensitivityChange = true;							///< Allow in-game sensitivity change		
 
@@ -189,6 +190,7 @@ protected:
 	/** Creates a GUI Pane for the specified user allowing changeable paramters to be changed */
 	void drawUserPane(const MenuConfig& config, UserConfig& user);
 
+	void updateUser(const String& id);
 	void updateUserPress();
 	void addUserPress();
 	void updateSessionPress();


### PR DESCRIPTION
This branch adds support for a `requireUserAdd` parameter in the general configuration of FPSci. When enabled this flag requires a new user to be added via the existing user menu prior to starting an experiment on each run of FPSci. Note that if FPSci is closed an existing user will still need to create a new user with the current implementation.

The user menu is drawn differently when `requireUserAdd = true`, will always be shown at startup, and cannot be closed until a new user is added in an effort to make the requirement more self-evident. Once a new user is added the typical user menu behavior resumes (allowing experiment configured user customization).

Merging this PR closes #373