### PR TITLE
Use `allSessionsCompleteFeedback` at startup

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -539,7 +539,7 @@ void Session::updatePresentationState()
 		else {
 			// Go ahead and move to the complete state since there aren't any valid sessions
 			newState = PresentationState::complete;
-			m_feedbackMessage = formatFeedback(m_config->feedback.allSessComplete);
+			m_feedbackMessage = formatFeedback(m_app->experimentConfig.feedback.allSessComplete);
 			moveOn = false;
 		}
 	}

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -539,7 +539,7 @@ void Session::updatePresentationState()
 		else {
 			// Go ahead and move to the complete state since there aren't any valid sessions
 			newState = PresentationState::complete;
-			m_feedbackMessage = formatFeedback("All sessions complete!");
+			m_feedbackMessage = formatFeedback(m_config->feedback.allSessComplete);
 			moveOn = false;
 		}
 	}


### PR DESCRIPTION
This branch moves to using the `allSessionsCompleteFeedback` string when starting up the application with no new sessions. Previously a hard coded message of `"All sessions complete!"` was used.

Merging this PR closes #378