### PR TITLE
Add alternate scoring models

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -140,6 +140,7 @@ For any/all of the feedback strings provided above, a number of `%`-delimited sp
 |`%trialTotalTargets`       | The number of total targets in the current trial                                      |
 |`%trialShotsHit`           | The number of shots the user hit in the current trial                                 |
 |`%trialTotalShots`         | The number of shots the user took in the current trial                                |
+|`%sessionScore`            | The total score (so far) for this session                                             |
 
 Using these custom strings we can implement the following (default) feedback messages:
 
@@ -150,9 +151,30 @@ maxPretrialAimDisplacement: "Invalid trial! Do not displace your aim during the 
 trialSuccessFeedback: "%trialTaskTimeMs ms!",
 trialFailureFeedback: "Failure!",
 blockCompleteFeedback: "Block %lastBlock complete! Starting block %currBlock.",
-sessionCompleteFeedback: "Session complete! You scored %totalTimeLeftS!",
+sessionCompleteFeedback: "Session complete! You scored %sessionScore!",
 allSessionsCompleteFeedback: "All Sessions Complete!",
 ```
+
+### Scoring
+First Person Science supports several different scoring modes to provide feedback to the user. Score can be displayed either via the [banner](#hud-settings) or through [feedback messages](#feedback-messages).
+
+Session scoring is set using the following parameters:
+
+| Parameter Name            |Units  | Description                                                        |
+|---------------------------|-------|--------------------------------------------------------------------|
+|`scoreModel`               |`String`| The score model (see table below)                                 |
+|`scoreMultiplier`          |`float` | A multiplier to apply to the raw score model described above      |
+
+The currently supported score models are described below (each model is an option for the `String` provided by the `scoreModel` parameter).
+
+|Score Model            |Description                                                                     |
+|-----------------------|--------------------------------------------------------------------------------|
+|`time remaining`       |Score the subject based on aggregate remaining time in trials (best for limited duration) |
+|`targets destroyed`    |Score the total number of targets destroyed in this session                     |
+|`shots hit`            |Score the total number of shots hit in this session                             |
+|`accuracy`             |Score the accuracy (as a 100-based percentage)                                  |
+|`trial successes`      |Score the total number of successful trials                                     |
+
 
 ## Rendering Settings
 | Parameter Name            |Units  | Description                                                        |

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -160,10 +160,10 @@ First Person Science supports several different scoring modes to provide feedbac
 
 Session scoring is set using the following parameters:
 
-| Parameter Name            |Units  | Description                                                        |
-|---------------------------|-------|--------------------------------------------------------------------|
-|`scoreModel`               |`String`| The score model (see table below)                                 |
-|`scoreMultiplier`          |`float` | A multiplier to apply to the raw score model described above      |
+| Parameter Name            |Units   | Description                                                                   |
+|---------------------------|-----=--|-------------------------------------------------------------------------------|
+|`scoreModel`               |`String`| The score model (see table below)                                             |
+|`scoreMultiplier`          |`float` | A multiplier to apply to the raw score model described above (100 by default) |
 
 The currently supported score models are described below (each model is an option for the `String` provided by the `scoreModel` parameter).
 
@@ -175,6 +175,20 @@ The currently supported score models are described below (each model is an optio
 |`accuracy`             |Score the accuracy (as a 100-based percentage)                                  |
 |`trial successes`      |Score the total number of successful trials                                     |
 
+The example (default) score settings are the following:
+
+```
+scoreModel = "time remaining";
+scoreMultiplier = 100;
+```
+
+If you prefer to report accuracy directly as a percentage, you could use the following:
+
+```
+scoreModel = "accuracy";
+scoreMultiplier = 1;
+sessionCompleteFeedback = "Session complete! You hit %sessionScore% of your shots.";
+```
 
 ## Rendering Settings
 | Parameter Name            |Units  | Description                                                        |

--- a/source/FPSciGraphics.cpp
+++ b/source/FPSciGraphics.cpp
@@ -519,16 +519,16 @@ void FPSciApp::drawHUD(RenderDevice *rd, Vector2 resolution) {
 
 		const double score = sess->getScore();
 		String score_string;
-		if (score < 1e3) {
+		if (score <= 1e4) {
 			score_string = format("%d", (int)G3D::round(score));
 		}
-		else if (score > 1e3 && score < 1e6) {
+		else if (score > 1e4 && score <= 1e7) {
 			score_string = format("%dk", (int)G3D::round(score / 1e3));
 		}
-		else if (score > 1e6 && score < 1e9) {
+		else if (score > 1e7 && score <= 1e10) {
 			score_string = format("%dM", (int)G3D::round(score / 1e6));
 		}
-		else if (score > 1e9) {
+		else if (score > 1e10) {
 			score_string = format("%dB", (int)G3D::round(score / 1e9));
 		}
 

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -388,6 +388,7 @@ Any TimingConfig::addToAny(Any a, bool forceAll) const {
 }
 
 void FeedbackConfig::load(FPSciAnyTableReader reader, int settingsVersion) {
+	String scoreModelStr;
 	switch (settingsVersion) {
 	case 1:
 		reader.getIfPresent("referenceTargetInitialFeedback", initialWithRef);
@@ -402,6 +403,15 @@ void FeedbackConfig::load(FPSciAnyTableReader reader, int settingsVersion) {
 		reader.getIfPresent("feedbackOutlineColor", outlineColor);
 		reader.getIfPresent("feedbackFontSize", fontSize);
 		reader.getIfPresent("feedbackBackgroundColor", backgroundColor);
+		
+		reader.getIfPresent("scoreModel", scoreModelStr);
+		if (!toLower(scoreModelStr).compare("time remaining")) scoreModel = ScoreType::TimeRemaining;
+		else if (!toLower(scoreModelStr).compare("targets destroyed")) scoreModel = ScoreType::TargetsDestroyed;
+		else if (!toLower(scoreModelStr).compare("shots hit")) scoreModel = ScoreType::ShotsHit;
+		else if (!toLower(scoreModelStr).compare("accuracy")) scoreModel = ScoreType::Accuracy;
+		else if (!toLower(scoreModelStr).compare("trial successes")) scoreModel = ScoreType::TrialSuccesses;
+		reader.getIfPresent("scoreMultiplier", scoreMultiplier);
+
 		break;
 	default:
 		throw format("Did not recognize settings version: %d", settingsVersion);
@@ -423,6 +433,16 @@ Any FeedbackConfig::addToAny(Any a, bool forceAll) const {
 	if (forceAll || def.outlineColor != outlineColor)		a["feedbackOutlineColor"] = outlineColor;
 	if (forceAll || def.fontSize != fontSize)				a["feedbackFontSize"] = fontSize;
 	if (forceAll || def.backgroundColor != backgroundColor) a["feedbackBackgroundColor"] = backgroundColor;
+	if (forceAll || def.scoreModel != scoreModel) {
+		String scoreStr = "unknown";
+		if (scoreModel == ScoreType::TimeRemaining) scoreStr = "time remaining";
+		else if (scoreModel == ScoreType::TargetsDestroyed) scoreStr = "targets destroyed";
+		else if (scoreModel == ScoreType::ShotsHit) scoreStr = "shots hit";
+		else if (scoreModel == ScoreType::Accuracy) scoreStr = "accuracy";
+		else if (scoreModel == ScoreType::TrialSuccesses) scoreStr = "trial successes";
+		a["scoreModel"] = scoreStr;
+	}
+	if (forceAll || def.scoreMultiplier != scoreMultiplier) a["scoreMultiplier"] = scoreMultiplier;
 	return a;
 }
 

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -176,8 +176,20 @@ public:
 	String trialSuccess = "%trialTaskTimeMs ms!";													///< Successful trial feedback message
 	String trialFailure = "Failure!";																///< Failed trial feedback message
 	String blockComplete = "Block %lastBlock complete! Starting block %currBlock.";					///< Block complete feedback message
-	String sessComplete = "Session complete! You scored %totalTimeLeftS!";							///< Session complete feedback message
+	String sessComplete = "Session complete! You scored %sessionScore!";							///< Session complete feedback message
 	String allSessComplete = "All Sessions Complete!";												///< All sessions complete feedback message
+
+	// Different supported scoring mechanism
+	enum ScoreType {
+		TimeRemaining,
+		TargetsDestroyed,
+		ShotsHit,
+		Accuracy,
+		TrialSuccesses
+	}; 
+
+	ScoreType scoreModel = ScoreType::TimeRemaining;				///< Score method to use for sessions
+	float scoreMultiplier = 100.f;
 
 	float fontSize = 20.0f;											///< Default font scale/size
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -307,7 +307,7 @@ void Session::initTargetAnimation() {
 	m_destroyedTargets = 0;
 	// Reset shot and hit counters (in the trial)
 	m_weapon->reload();
-	m_hitCount = 0;
+	m_trialShotsHit = 0;
 }
 
 void Session::spawnTrialTargets(Point3 initialSpawnPos, bool previewMode) {
@@ -648,7 +648,7 @@ void Session::accumulatePlayerAction(PlayerActionType action, String targetName)
 			m_accuracy = (float) m_totalShotsHit / (float) m_totalShots * 100.f;
 		}
 		if ((action == PlayerActionType::Hit || action == PlayerActionType::Destroy)) {
-			m_hitCount++;
+			m_trialShotsHit++;
 			// Update scoring parameters
 			m_totalShotsHit++;
 			m_totalShots += 1;
@@ -819,7 +819,7 @@ String Session::formatFeedback(const String& input) {
 			formatted = formatted.substr(0, foundIdx) + totalTargetsString + formatted.substr(foundIdx + trialTotalTargets.length());
 		}
 		else if (!formatted.compare(foundIdx, trialShotsHit.length(), trialShotsHit)) {
-			formatted = formatted.substr(0, foundIdx) + format("%d", m_hitCount) + formatted.substr(foundIdx + trialShotsHit.length());
+			formatted = formatted.substr(0, foundIdx) + format("%d", m_trialShotsHit) + formatted.substr(foundIdx + trialShotsHit.length());
 		}
 		else if (!formatted.compare(foundIdx, trialTotalShots.length(), trialTotalShots)) {
 			formatted = formatted.substr(0, foundIdx) + format("%d", m_weapon->shotsTaken()) + formatted.substr(foundIdx + trialTotalShots.length());

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -378,6 +378,7 @@ void Session::processResponse()
 	// Check for whether all targets have been destroyed
 	if (m_destroyedTargets == totalTargets) {
 		m_totalRemainingTime += (double(m_config->timing.maxTrialDuration) - m_taskExecutionTime);
+		m_totalTrialSuccesses += 1;
 		m_feedbackMessage = formatFeedback(m_config->feedback.trialSuccess);
 	}
 	else {
@@ -641,7 +642,20 @@ void Session::accumulateTrajectories()
 void Session::accumulatePlayerAction(PlayerActionType action, String targetName)
 {
 	// Count hits (in task state) here
-	if ((action == PlayerActionType::Hit || action == PlayerActionType::Destroy) && currentState == PresentationState::trialTask) { m_hitCount++; }
+	if (currentState == PresentationState::trialTask) {
+		if (action == PlayerActionType::Miss) {
+			m_totalShots += 1;
+			m_accuracy = (float) m_totalShotsHit / (float) m_totalShots * 100.f;
+		}
+		if ((action == PlayerActionType::Hit || action == PlayerActionType::Destroy)) {
+			m_hitCount++;
+			// Update scoring parameters
+			m_totalShotsHit++;
+			m_totalShots += 1;
+			m_accuracy = (float) m_totalShotsHit / (float) m_totalShots * 100.f;
+			if (action == PlayerActionType::Destroy) m_totalTargetsDestroyed += 1;
+		}
+	}
 
 	static PlayerAction lastPA;
 
@@ -693,7 +707,30 @@ float Session::getProgress() {
 }
 
 double Session::getScore() {
-	return 100.0 * m_totalRemainingTime;
+	if (isNull(m_config)) return 0;
+
+	double score = 0;
+	switch (m_config->feedback.scoreModel) {
+	case FeedbackConfig::ScoreType::TimeRemaining:
+		score = m_totalRemainingTime;
+		break;
+	case FeedbackConfig::ScoreType::TargetsDestroyed:
+		score = m_totalTargetsDestroyed;
+		break;
+	case FeedbackConfig::ScoreType::ShotsHit:
+		score = m_totalShotsHit;
+		break;
+	case FeedbackConfig::ScoreType::Accuracy:
+		score = m_accuracy;
+		break;
+	case FeedbackConfig::ScoreType::TrialSuccesses:
+		score = m_totalTrialSuccesses;
+		break;
+	default:
+		break;
+	}
+
+	return m_config->feedback.scoreMultiplier * score;
 }
 
 String Session::formatCommand(const String& input) {
@@ -746,6 +783,7 @@ String Session::formatFeedback(const String& input) {
 	const String trialTotalTargets		= "%trialTotalTargets";				///< The number of targets in this trial ("infinite" if any target respawns infinitely)
 	const String trialShotsHit			= "%trialShotsHit";					///< The number of shots hit in this trial
 	const String trialTotalShots		= "%trialTotalShots";				///< The number of shots taken in this trial
+	const String sessionScore			= "%sessionScore";					///< The score for this session
 
 	// Walk through the string looking for instances of the delimiter
 	while ((foundIdx = (int)formatted.find(delimiter, (size_t)foundIdx)) > -1) {
@@ -785,6 +823,9 @@ String Session::formatFeedback(const String& input) {
 		}
 		else if (!formatted.compare(foundIdx, trialTotalShots.length(), trialTotalShots)) {
 			formatted = formatted.substr(0, foundIdx) + format("%d", m_weapon->shotsTaken()) + formatted.substr(foundIdx + trialTotalShots.length());
+		}
+		else if (!formatted.compare(foundIdx, sessionScore.length(), sessionScore)) {
+			formatted = formatted.substr(0, foundIdx) + format("%d", (int)G3D::round(getScore())) + formatted.substr(foundIdx + sessionScore.length());
 		}
 		else {
 			// Bump the found index past this character (not a valid substring)

--- a/source/Session.h
+++ b/source/Session.h
@@ -201,10 +201,17 @@ protected:
 	RealTime m_taskExecutionTime;						///< Task completion time for the most recent trial
 	String m_taskStartTime;								///< Recorded task start timestamp							
 	String m_taskEndTime;								///< Recorded task end timestamp
-	RealTime m_totalRemainingTime = 0;					///< Time remaining in the trial
 	Timer m_timer;										///< Timer used for timing tasks	
 	// Could move timer above to stopwatch in future
 	//Stopwatch stopwatch;			
+
+	// Scoring mechanisms
+	RealTime m_totalRemainingTime = 0;					///< Time remaining in the trial
+	int m_totalTargetsDestroyed = 0;					///< Total number of targets destroyed
+	int m_totalShots = 0;								///< Total number of shots taken
+	int m_totalShotsHit = 0;							///< Total number of shots hit
+	float m_accuracy = 0;								///< Overall accuracy
+	int m_totalTrialSuccesses = 0;						///< Total number of successful trials
 
 	Array<HANDLE> m_sessProcesses;						///< Handles for session-level processes
 	Array<HANDLE> m_trialProcesses;						///< Handles for trial-level processes

--- a/source/Session.h
+++ b/source/Session.h
@@ -172,7 +172,7 @@ protected:
 
 	// Experiment management					
 	int m_destroyedTargets = 0;							///< Number of destroyed target
-	int m_hitCount = 0;									///< Count of total hits in this trial
+	int m_trialShotsHit = 0;									///< Count of total hits in this trial
 	bool m_hasSession;									///< Flag indicating whether psych helper has loaded a valid session
 	int	m_currBlock = 1;								///< Index to the current block of trials
 	Array<Array<shared_ptr<TargetConfig>>> m_trials;	///< Storage for trials (to repeat over blocks)


### PR DESCRIPTION
This branch adds support for some additional scoring models for FPSci. Specifically it adds support for a `scoreModel` and `scoreMultiplier` parameter that allow more customization of scoring. Valid `scoreModel`s include `time remaining` (historical), `targets destroyed`, `shots hit`, `accuracy`, and `trial successes`.

We can add more scoring modes in the future if we would like using this model.