### PR TITLE
Replace single quotes w/ correct escape

### DIFF
--- a/source/sqlHelpers.h
+++ b/source/sqlHelpers.h
@@ -7,3 +7,4 @@
 bool createTableInDB(sqlite3* db, const String tableName, const Array<Array<String>>& columns);
 bool insertRowIntoDB(sqlite3* db, const String tableName, const Array<String>& values, const String colNames = "");
 bool insertRowsIntoDB(sqlite3* db, const String tableName, const Array<Array<String>>& valueVector, const String colNames = "");
+bool replaceSingleQuote(String& str);


### PR DESCRIPTION
This branch replaces `'` characters with `''` in order to avoid issues with single quotes in database contents (i.e. experiment configuration) breaking writes to the database.

Merging this branch closes #383 