### PR TITLE
Close on complete fix

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -515,22 +515,12 @@ void Session::updatePresentationState()
 				closeSessionProcesses();					// Close the process we started at session start (if there is one)
 				runSessionCommands("end");					// Launch processes for the end of the session
 
-				Array<String> remaining = m_app->updateSessionDropDown();
-				if (remaining.size() == 0) {
-					// Currently this code is never run as updateSessionDropDown() always returns an array of at least length 1...
-					m_feedbackMessage = formatFeedback(m_config->feedback.allSessComplete); // Update the feedback message
-					moveOn = false;
-					if (m_app->experimentConfig.closeOnComplete || m_config->closeOnComplete) {
-						m_app->quitRequest();
-					}
+				m_app->updateSessionDropDown();
+				m_feedbackMessage = formatFeedback(m_config->feedback.sessComplete);	// Update the feedback message
+				if (m_config->closeOnComplete) {
+					m_app->quitRequest();
 				}
-				else {
-					m_feedbackMessage = formatFeedback(m_config->feedback.sessComplete);	// Update the feedback message
-					if (m_config->closeOnComplete) {
-						m_app->quitRequest();
-					}
-					moveOn = true;														// Check for session complete (signal start of next session)
-				}
+				moveOn = true;														// Check for session complete (signal start of next session)
 			}
 		}
 		else {

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -517,6 +517,7 @@ void Session::updatePresentationState()
 
 				Array<String> remaining = m_app->updateSessionDropDown();
 				if (remaining.size() == 0) {
+					// Currently this code is never run as updateSessionDropDown() always returns an array of at least length 1...
 					m_feedbackMessage = formatFeedback(m_config->feedback.allSessComplete); // Update the feedback message
 					moveOn = false;
 					if (m_app->experimentConfig.closeOnComplete || m_config->closeOnComplete) {
@@ -530,10 +531,6 @@ void Session::updatePresentationState()
 					}
 					moveOn = true;														// Check for session complete (signal start of next session)
 				}
-
-				if (m_app->experimentConfig.closeOnComplete) {
-					m_app->quitRequest();
-				}
 			}
 		}
 		else {
@@ -541,6 +538,9 @@ void Session::updatePresentationState()
 			newState = PresentationState::complete;
 			m_feedbackMessage = formatFeedback("All sessions complete!");
 			moveOn = false;
+			if (m_app->experimentConfig.closeOnComplete) {		// This is the case that is used for experiment config closeOnComplete!
+				m_app->quitRequest();
+			}
 		}
 	}
 


### PR DESCRIPTION
This branch fixes an error with `closeOnComplete` that caused experiment-level specification of the parameter to not work as intended. It also removes some unused code handling no remaining sessions in a way FPSci no longer supports. This branch should return the experiment-level `closeOnComplete` parameter to its desired behavior.

Merging this PR closes #387.