### PR TITLE
Getenv null check

### DIFF
--- a/source/SystemConfig.h
+++ b/source/SystemConfig.h
@@ -14,7 +14,7 @@ public:
 	SystemConfig(const Any& any);
 
 	static SystemConfig load(String filename, bool saveJSON);
-	Any toAny(const bool forceAll = true) const;
+	Any toAny(const bool forceAll = false) const;
 	void printToLog();					// Print the latency logger config to log.txt
 
 };

--- a/source/SystemInfo.cpp
+++ b/source/SystemInfo.cpp
@@ -3,8 +3,13 @@
 SystemInfo SystemInfo::get(void) {
 	SystemInfo info;
 
-	info.hostName = getenv("COMPUTERNAME");		// Get the host (computer) name
-	info.userName = getenv("USERNAME");			// Get the current logged in username
+	char *ptr = getenv("COMPUTERNAME");		// Get the host (computer) name (if available)
+	if (notNull(ptr)) info.hostName = ptr;
+	else info.hostName = "unknown";
+
+	ptr = getenv("USERNAME");				// Get the current logged in username (if available)
+	if (notNull(ptr))  info.userName = ptr;
+	else info.userName = "unknown";
 
 	// Get CPU name string
 	int cpuInfo[4] = { -1 };

--- a/source/SystemInfo.h
+++ b/source/SystemInfo.h
@@ -20,6 +20,6 @@ public:
 
 	static SystemInfo get(void);						// Get the system info using (windows) calls
 
-	Any toAny(const bool forceAll = true) const;
+	Any toAny(const bool forceAll = false) const;
 	void printToLog();
 };


### PR DESCRIPTION
This branch adds support for null checking results of `std::getenv()` calls which can be `null` when the requested values aren't set in the environment variables (as documented [here](https://en.cppreference.com/w/cpp/utility/program/getenv)).

Merging this PR closes #398.

