### PR TITLE
Reset weapon cooldowns at the start of kill tests

### DIFF
--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -288,6 +288,7 @@ TEST_F(FPSciTests, KillTargetFront) {
 	EXPECT_EQ(s_app->sess->currentState, PresentationState::trialTask);
 
 	int spawnedTargets = respawnTargets();
+	s_app->weapon->resetCooldown();
 
 	// Kill the front target - just fire
 	zeroCameraRotation();
@@ -305,7 +306,8 @@ TEST_F(FPSciTests, KillTargetFrontHoldclick) {
 	EXPECT_EQ(s_app->sess->currentState, PresentationState::trialTask);
 	
 	int spawnedTargets = respawnTargets();
-	
+	s_app->weapon->resetCooldown();
+
 	zeroCameraRotation();
 	s_fakeInput->window().injectMouseDown(0);
 	s_app->oneFrame();
@@ -324,6 +326,7 @@ TEST_F(FPSciTests, KillTargetRightRotate) {
 	EXPECT_EQ(s_app->sess->currentState, PresentationState::trialTask);
 
 	int spawnedTargets = respawnTargets();
+	s_app->weapon->resetCooldown();
 
 	// Kill the right target by rotating to line it up
 	zeroCameraRotation();
@@ -347,6 +350,7 @@ TEST_F(FPSciTests, KillTargetRightTranslate) {
 	EXPECT_EQ(s_app->sess->currentState, PresentationState::trialTask);
 	
 	int spawnedTargets = respawnTargets();
+	s_app->weapon->resetCooldown();
 
 	zeroCameraRotation();
 	auto player = getPlayer();


### PR DESCRIPTION
This branch resets the weapon cooldown at the start of target kill tests. Since app state isn't reset between tests the weapon cooldown was (in some cases) preventing a fire event from occurring as the weapon is still in its 0.1s cooldown.

Overall we should probably improve test infrastructure by resetting most of this state in the app prior to running each test instead of just relying on the fixture to do this. It is likely a certain sequence of tests could potentially still result in (illegitimate) failures.

Merging this PR closes #275 and closes #243.