### PR TITLE
Fixes for reticle preview and `allowReticleChange`

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -474,7 +474,7 @@ In addition to being able to be specified on a per-user basis, the experiment/se
 |`reticleColor`         |`Array<Color4>` |Provides a range of colors over which to set the reticle color as an `Array` w/ 2 elements (min, max)|
 |`reticleChangeTime`    |`float`         |Provides the time (in seconds) for the reticle to change color and/or size following a shot          |
 
-Note that when these values are specified at the experiment or session level the `allowReticleChange` property of the [menu configuration](#menu-config) should be set to `false` as user changes to the reticle will not apply.
+Note that when these values are specified at the experiment, session, or trial level the `allowReticleChange` property of the [menu configuration](#menu-config) can still be set to `true` but only fields *not* specified in the experiment/session/trial will be displayed as editable in the user menu. If all config is specified in by the experiment then the reticle pane/preview is not shown in the user menu.
 
 ### Weapon Cooldown
 | Parameter Name        |Units| Description                                                                             |

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -710,6 +710,7 @@ void FPSciApp::updateSession(const String& id, const bool forceSceneReload) {
 
 void FPSciApp::updateTrial(const shared_ptr<TrialConfig> config, const bool forceSceneReload, const bool respawn) {
 	trialConfig = config;	// Naive way to store trial config pointer for now
+	updateUserMenu = true;
 	updateConfigParameters(config, forceSceneReload, respawn);
 }
 
@@ -1404,12 +1405,28 @@ void FPSciApp::onUserInput(UserInput* ui) {
 		}
 	}
 
-	if (m_lastReticleLoaded != currentUser()->reticle.index || m_userSettingsWindow->visible()) {
+	// Update reticle from user settings change (if needed)
+	if (reticleConfig != currentUser()->reticle || m_userSettingsWindow->visible()) {
+		bool updateReticlePreview = false;
 		// Slider was used to change the reticle
 		if (!trialConfig->reticle.indexSpecified) {		// Only allow reticle change if it isn't specified in experiment config
 			setReticle(currentUser()->reticle.index);
-			m_userSettingsWindow->updateReticlePreview();
+			updateReticlePreview = true;
 		}
+		if (!trialConfig->reticle.scaleSpecified) {
+			reticleConfig.scale = currentUser()->reticle.scale;
+			updateReticlePreview = true;
+		}
+		if (!trialConfig->reticle.colorSpecified) {
+			reticleConfig.color = currentUser()->reticle.color;
+			updateReticlePreview = true;
+		}
+		if (!trialConfig->reticle.changeTimeSpecified) {
+			reticleConfig.changeTimeS = currentUser()->reticle.changeTimeS;
+			updateReticlePreview = true;
+		}
+		if(updateReticlePreview) m_userSettingsWindow->updateReticlePreview();
+
 	}
 
 	playerCamera->filmSettings().setSensitivity(sceneBrightness);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -463,6 +463,12 @@ UserMenu::UserMenu(FPSciApp* app, UserTable& users, UserStatusTable& userStatus,
 	// User Settings Pane
 	if (config.showUserSettings && !needUser) {
 		m_currentUserPane = m_parent->addPane("Current User Settings");
+		// Update config based on what is specified at the trial-level
+		if (app->trialConfig->reticle.indexSpecified) config.allowReticleIdxChange = false;
+		if (app->trialConfig->reticle.scaleSpecified) config.allowReticleSizeChange = false;
+		if (app->trialConfig->reticle.colorSpecified) config.allowReticleColorChange = false;
+		if (app->trialConfig->reticle.changeTimeSpecified) config.allowReticleChangeTimeChange = false;
+		config.allowReticleChange = config.allowReticleIdxChange || config.allowReticleSizeChange || config.allowReticleColorChange || config.allowReticleChangeTimeChange;
 		drawUserPane(config, m_users.users[m_users.getUserIndex(m_userStatus.currentUser)]);
 	}
 
@@ -610,13 +616,14 @@ void UserMenu::drawUserPane(const MenuConfig& config, UserConfig& user)
 				a->setWidth(m_rgbSliderWidth);
 				a->moveRightOf(b, rgbCaptionWidth);
 			} reticleControlPane->endRow();
-			if (config.allowReticleChangeTimeChange) {
-				reticleControlPane->beginRow(); {
-					auto c = reticleControlPane->addNumberBox("Reticle Change Time", &(user.reticle.changeTimeS), "s", GuiTheme::LINEAR_SLIDER, 0.0f, 5.0f, 0.01f);
-					c->setCaptionWidth(150.0f);
-					c->setWidth(m_sliderWidth);
-				} reticleControlPane->endRow();
-			}
+		}
+
+		if (config.allowReticleChangeTimeChange) {
+			reticleControlPane->beginRow(); {
+				auto c = reticleControlPane->addNumberBox("Reticle Change Time", &(user.reticle.changeTimeS), "s", GuiTheme::LINEAR_SLIDER, 0.0f, 5.0f, 0.01f);
+				c->setCaptionWidth(150.0f);
+				c->setWidth(m_sliderWidth);
+			} reticleControlPane->endRow();
 		}
 
 		// Draw a preview of the reticle here
@@ -761,7 +768,7 @@ void UserMenu::updateReticlePreview() {
 	m_reticlePreviewPane->removeAllChildren();
 	// Redraw the preview
 	shared_ptr<Texture> reticleTex = m_app->reticleTexture;
-	Color4 rColor = m_users.getUserById(m_userStatus.currentUser)->reticle.color[0];
+	Color4 rColor = m_app->reticleConfig.color[0];
 
 	RenderDevice* rd = m_app->renderDevice;
 	rd->push2D(m_reticleBuffer); {

--- a/source/UserConfig.h
+++ b/source/UserConfig.h
@@ -18,6 +18,13 @@ public:
 
 	void load(FPSciAnyTableReader reader, int settingsVersion = 1);
 	Any addToAny(Any a, bool forceAll = false) const;
+	bool operator!=(ReticleConfig other) {
+		return index != other.index ||
+			scale[0] != other.scale[0] || scale[1] != other.scale[1] ||
+			color[0] != other.color[0] || color[1] != other.color[1] ||
+			changeTimeS != other.changeTimeS;
+	}
+
 };
 
 /**Class for managing user configuration*/


### PR DESCRIPTION
This branch fixes a buggy interaction between specifying reticle configuration parameters at the experiment/session/trial level and using `allowReticleChange = true` to enable the user menu reticle configuration GUI.

The app now treats specifying any reticle configuration at the experiment/session/trial level as equivalent to setting the corresponding field's `allowReticle[X]Change` parameter to `false`. Thus the only reticle parameters users are free to configure are those not specified as part of experiment configuration. 

Merging this PR closes #361 