### PR TITLE
Set guard band to 0

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1682,7 +1682,7 @@ FPSciApp::Settings::Settings(const StartupConfig& startupConfig, int argc, const
 
 	useDeveloperTools = startupConfig.developerMode;
 
-	hdrFramebuffer.depthGuardBandThickness = Vector2int16(64, 64);
+	hdrFramebuffer.depthGuardBandThickness = Vector2int16(0, 0);
 	hdrFramebuffer.colorGuardBandThickness = Vector2int16(0, 0);
 	dataDir = FileSystem::currentDirectory();
 	screenCapture.includeAppRevision = false;


### PR DESCRIPTION
This PR sets the guard band to 0 instead of 64 like it was previously. This effectively fixes and issue that the configured FoV was 93.75% of the intended value (1920/2048) at 1080p.

I'm not sure if this is the fix we want for this issue yet.

**IMPORTANT: This breaks backwards compatibility with older experiments since the FoV setting gives different results.**