### PR TITLE
Don't modify widget manager prior to reinit

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1202,9 +1202,6 @@ void FPSciApp::onAfterEvents() {
 	}
 
 	if (reinitExperiment) {			// Check for experiment reinitialization (developer-mode only)
-		m_widgetManager->clear();
-		addWidget(debugWindow);
-		addWidget(developerWindow);
 		initExperiment();
 		reinitExperiment = false;
 	}


### PR DESCRIPTION
This branch fixes exceptions thrown when changing experiments using the GUI in debug mode. The fix is simply not to modify the `m_widgetManager` prior to reinitializing the application.