### PR TITLE
Don't load weapon sounds if audio disabled

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -779,7 +779,7 @@ void FPSciApp::updateConfigParameters(const shared_ptr<FpsConfig> config, const 
 
 		// Update weapon model (if drawn) and sounds
 		weapon->loadModels();
-		weapon->loadSounds();
+		if(startupConfig.audioEnable) weapon->loadSounds();
 		if (!config->audio.sceneHitSound.empty()) {
 			m_sceneHitSound = Sound::create(System::findDataFile(config->audio.sceneHitSound));
 			// Play silently to pre-load the sound


### PR DESCRIPTION
This branch fixes an issue in the `Weapon::loadSounds()` call that was creating an exception when `audioEnable` was set to `false` in the startup config. 

Merging this branch closes #413.