### PR TITLE
Check whether a dialog is present before FPM mode

### DIFF
--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -806,5 +806,6 @@ void UserMenu::setVisible(bool enable) {
 void UserMenu::resumePress() {
 	if (m_config.requireUserAdd && !m_app->userAdded) return;
 	setVisible(!visible());
-	m_app->setMouseInputMode(visible() ? FPSciApp::MouseInputMode::MOUSE_CURSOR : FPSciApp::MouseInputMode::MOUSE_FPM);
+	if (visible()) m_app->setMouseInputMode(FPSciApp::MouseInputMode::MOUSE_CURSOR);					// If the window is visible always set cursor mode
+	else if (isNull(m_app->dialog)) m_app->setMouseInputMode(FPSciApp::MouseInputMode::MOUSE_FPM);		// Only revert to FPM mode if the window isn't visible and a dialog isn't present
 }


### PR DESCRIPTION
This branch adds a check for whether a dialog is open prior to entering `MOUSE_FPM` mode (first-person view) in FPSci. Currently it only does this for a single path (user menu `Resume` button), but we could extend this to be the way we set the mouse mode more generally in FPSci (i.e. only change the mouse mode to `MOUSE_FPM` when neither a dialog nor the menu is present).

Merging this PR closes #417.