### PR TITLE
Default to not allowing any reticle changes

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -718,9 +718,9 @@ These flags control the display of the in-game user menu:
 "xTurnScaleAdjustMode": "None",         // Don't allow X-turn scale adjustment (use sensitivity)
 "yTurnScaleAdjustMode": "Invert",       // Only allow simple "invert" behavior for Y turn scale
 "allowReticleChange": false,            // Don't allow the user to change the reticle (ignore below)
-"allowReticleIdxChange": true,          // If reticle changes are enabled, allow index (reticle style) changes
-"allowReticleSizeChange": true,         // If reticle changes are enabled, allow size changes
-"allowReticleColorChange": true,        // If reticle changes are enabled, allow color changes
+"allowReticleIdxChange": false,         // If reticle changes are enabled, allow index (reticle style) changes
+"allowReticleSizeChange": false,        // If reticle changes are enabled, allow size changes
+"allowReticleColorChange": false,       // If reticle changes are enabled, allow color changes
 "allowReticleTimeChange": false,        // Even if reticle change is enabled, don't allow "shrink time" to change
 "showReticlePreview": true,             // If reticle changes are enabled show the preview
 "showMenuOnStartup" : true,             // Show the user menu when the application starts

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -26,9 +26,9 @@ public:
 	String yTurnScaleAdjustMode = "Invert";						///< Y turn scale adjustment mode (can be "None", "Invert", or "Slider")
 
 	bool allowReticleChange = false;							///< Allow the user to adjust their crosshair
-	bool allowReticleIdxChange = true;							///< If reticle change is allowed, allow index change
-	bool allowReticleSizeChange = true;							///< If reticle change is allowed, allow size change
-	bool allowReticleColorChange = true;						///< If reticle change is allowed, allow color change
+	bool allowReticleIdxChange = false;							///< If reticle change is allowed, allow index change
+	bool allowReticleSizeChange = false;						///< If reticle change is allowed, allow size change
+	bool allowReticleColorChange = false;						///< If reticle change is allowed, allow color change
 	bool allowReticleChangeTimeChange = false;					///< Allow the user to change the reticle change time
 	bool showReticlePreview = true;								///< Show a preview of the reticle
 


### PR DESCRIPTION
This branch restores historical behavior by setting `allowReticle[X]` flags to `false` such that no reticle preview is displayed and users can't change reticles in historical experiments (i.e. SIGA) where this was the default behavior due to a change in how `allowReticleChange`'s value impacted user menu control.

Merging this branch is optional if we want to return to this historical behavior.