### PR TITLE
Only strafe ever N calls to slideMove

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -619,6 +619,8 @@ void FPSciApp::initPlayer(const shared_ptr<FpsConfig> config, const bool respawn
 	player->height = &config->player.height;
 	player->crouchHeight = &config->player.crouchHeight;
 
+	player->strafeDivider = &config->render.strafeDivider;
+
 	// Respawn player
 	if (respawn) player->respawn();
 	updateMouseSensitivity();

--- a/source/FpsConfig.cpp
+++ b/source/FpsConfig.cpp
@@ -100,6 +100,8 @@ void RenderConfig::load(FPSciAnyTableReader reader, int settingsVersion) {
 		reader.getIfPresent("frameDelay", frameDelay);
 		reader.getIfPresent("frameTimeArray", frameTimeArray);
 		reader.getIfPresent("frameTimeRandomize", frameTimeRandomize);
+
+		reader.getIfPresent("strafeDivider", strafeDivider);
 		
 		reader.getIfPresent("frameTimeMode", frameTimeMode);
 		frameTimeMode = toLower(frameTimeMode);	// Convert to lower case
@@ -169,7 +171,9 @@ Any RenderConfig::addToAny(Any a, bool forceAll) const {
 	if (forceAll || def.samplerPrecomposite != samplerPrecomposite)	a["samplerPrecomposite"] = samplerPrecomposite;
 	if (forceAll || def.samplerComposite != samplerComposite)	a["samplerComposite"] = samplerComposite;
 	if (forceAll || def.samplerFinal != samplerFinal)			a["samplerFinal"] = samplerFinal;
-	
+
+	if (forceAll || def.strafeDivider != strafeDivider)			a["strafeDivider"] = strafeDivider;
+
 	return a;
 }
 

--- a/source/FpsConfig.h
+++ b/source/FpsConfig.h
@@ -29,6 +29,7 @@ public:
 	// Rendering parameters
 	float           frameRate = 1000.0f;						///< Target (goal) frame rate (in Hz)
 	int             frameDelay = 0;								///< Integer frame delay (in frames)
+	int				strafeDivider = 1;							///< Integer number of frames between move updates
 	Array<float>	frameTimeArray = { };						///< Array of target frame times (in seconds)
 	bool			frameTimeRandomize = false;					///< Whether to choose a sequential or random item from frameTimeArray
 	String			frameTimeMode = "always";					///< Mode to use for frame time selection (can be "always", "taskOnly", or "restartWithTask", case insensitive)

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -229,6 +229,10 @@ RenderControls::RenderControls(FPSciApp* app, FpsConfig& config, bool& drawFps, 
 		c->setWidth(width*0.95f);
 	} framePane->endRow();
 	framePane->beginRow(); {
+		auto c = framePane->addNumberBox("Strafe every", &(config.render.strafeDivider), "frames", GuiTheme::LINEAR_SLIDER, 1, 360, 1);
+		c->setWidth(width * 0.95f);
+	} framePane->endRow();
+	framePane->beginRow(); {
 		auto c = framePane->addNumberBox("Display Lag", &(config.render.frameDelay), "f", GuiTheme::LINEAR_SLIDER, 0, maxFrameDelay);
 		c->setWidth(width*0.95f);
 	}framePane->endRow();

--- a/source/PlayerEntity.h
+++ b/source/PlayerEntity.h
@@ -46,6 +46,8 @@ public:
 	float			m_cameraRadiansPerMouseDot;		///< Player mouse sensitivity
 	Vector2			turnScale;				///< Player asymmetric mouse scaler - typically near 1:1
 
+    int*            strafeDivider;              ///< Integer how many frames to count between updating strafing
+
 	float*			moveRate = nullptr;	        ///< Player movement rate (m/s)
 	Vector2*		moveScale = nullptr;	    ///< Player X/Y movement scale vector (interpreted as unit vector)
 	Array<bool>*	axisLock = nullptr;		    ///< World-space axis lock


### PR DESCRIPTION
This PR adds a `strafeDivider` parameter to the general config which can be used to cause the player's `slideMove()` function to only be called 1 in `strafeDivider` frames. The code hasn't been tested yet, but I wanted to get the idea in place in case we end up finding it useful.

Still TODO:

- [ ] Documentation
- [ ] Test functionality